### PR TITLE
동명이인에 대한 납부처리 로직

### DIFF
--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -141,7 +141,7 @@ public class PaymentController {
     @PostMapping("/generateKeys/{yearMonth}")
     public ResponseEntity<?> generatePaymentKeys(@PathVariable(name = "yearMonth") YearMonth yearMonth, Principal principal) {
         final String userId = principal.getName();
-        paymentService.generatePaymentKeys(yearMonth, userId);
+        paymentService.handleStudentPaymentProcessing(yearMonth, userId);
 
         return ResponseEntity.ok("학생 납부처리 후 결제키 생성 완료");
     }

--- a/src/main/java/com/edubill/edubillApi/excel/ExcelServiceImpl.java
+++ b/src/main/java/com/edubill/edubillApi/excel/ExcelServiceImpl.java
@@ -40,7 +40,7 @@ public class ExcelServiceImpl implements ExcelService {
         ConvertService convertService = convertServiceResolver.resolve(BankName.valueOf(bankName));
         List<PaymentHistory> paymentHistories = convertService.convertBankExcelDataToPaymentHistory(file, userId);
         paymentService.savePaymentHistories(paymentHistories);
-        paymentService.generatePaymentKeys(yearMonth, userId);
+        paymentService.handleStudentPaymentProcessing(yearMonth, userId);
     }
 
     @Override

--- a/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepository.java
@@ -1,11 +1,16 @@
 package com.edubill.edubillApi.repository.student;
 
 import com.edubill.edubillApi.domain.Student;
+import com.edubill.edubillApi.domain.StudentGroup;
 
 import java.time.YearMonth;
+import java.util.Collection;
 import java.util.List;
 
 public interface StudentCustomRepository {
     List<Student> findStudentsWhereDepositorNameEqualsStudentNameByYearMonthAndManagerId(String userId, YearMonth yearMonth);
     List<Student> findStudentsByDepositorNameEqualsParentName();
+
+    List<Student> findStudentsWithDuplicateNames(Collection<StudentGroup> studentGroups);
+    List<Student> findStudentsWithUniqueNames(Collection<StudentGroup> studentGroups);
 }

--- a/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepositoryImpl.java
@@ -1,12 +1,16 @@
 package com.edubill.edubillApi.repository.student;
 
+import com.edubill.edubillApi.domain.QStudent;
 import com.edubill.edubillApi.domain.Student;
+import com.edubill.edubillApi.domain.StudentGroup;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.Collection;
 import java.util.List;
 
 import static com.edubill.edubillApi.domain.QPaymentHistory.paymentHistory;
@@ -40,6 +44,38 @@ public class StudentCustomRepositoryImpl implements StudentCustomRepository{
                 .select(student)
                 .from(student, paymentHistory)
                 .where(student.parentName.eq(paymentHistory.depositorName))
+                .fetch();
+    }
+
+    @Override
+    public List<Student> findStudentsWithDuplicateNames(Collection<StudentGroup> studentGroups) {
+        QStudent student = QStudent.student;
+
+        return queryFactory
+                .selectFrom(student)
+                .where(student.studentGroup.in(studentGroups)
+                        .and(student.studentName.in(
+                                JPAExpressions.select(student.studentName)
+                                        .from(student)
+                                        .groupBy(student.studentName)
+                                        .having(student.count().gt(1))
+                        )))
+                .fetch();
+    }
+
+    @Override
+    public List<Student> findStudentsWithUniqueNames(Collection<StudentGroup> studentGroups) {
+        QStudent student = QStudent.student;
+
+        return queryFactory
+                .selectFrom(student)
+                .where(student.studentGroup.in(studentGroups)
+                        .and(student.studentName.in(
+                                JPAExpressions.select(student.studentName)
+                                        .from(student)
+                                        .groupBy(student.studentName)
+                                        .having(student.count().eq(1L))
+                        )))
                 .fetch();
     }
 }

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -99,31 +99,16 @@ public class PaymentService {
 
     @Transactional
     public void generatePaymentKeys(YearMonth yearMonth, String userId) {
-        //paymentHistory에 userId를 추가하여 외래키로 가지고 있음.
+        //paymentHistory 에 userId를 추가하여 외래키로 가지고 있음.
         List<PaymentHistory> paymentHistories = paymentHistoryRepository.findPaymentHistoriesWithUserIdAndYearMonth(userId, yearMonth);
         List<StudentGroup> studentGroups = studentGroupRepository.getStudentGroupsByUserId(userId);
-        List<Student> students = new ArrayList<>();
 
-        for (StudentGroup studentGroup : studentGroups) {
-            students.addAll(studentRepository.findAllByStudentGroup(studentGroup));
-        }
+        // 중복된 이름을 가진 학생들 가져오기
+        List<Student> duplicateNameStudents = studentRepository.findStudentsWithDuplicateNames(studentGroups);
 
-        // 학생을 이름별로 그룹화
-        Map<String, List<Student>> studentsGroupedByName = students.stream()
-                .collect(Collectors.groupingBy(Student::getStudentName));
+        // 유니크한 이름을 가진 학생들 가져오기
+        List<Student> uniqueStudents = studentRepository.findStudentsWithUniqueNames(studentGroups);
 
-        // 동명이인이 있는 학생과 없는 학생을 분리
-        List<Student> uniqueStudents = new ArrayList<>();
-        List<Student> duplicateNameStudents = new ArrayList<>();
-
-        for (Map.Entry<String, List<Student>> entry : studentsGroupedByName.entrySet()) {
-            List<Student> groupedStudents = entry.getValue();
-            if (groupedStudents.size() == 1) {
-                uniqueStudents.addAll(groupedStudents);
-            } else {
-                duplicateNameStudents.addAll(groupedStudents);
-            }
-        }
 
         // 유니크한 학생에 대한 처리
         for (Student student : uniqueStudents) {

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -99,7 +99,7 @@ public class PaymentService {
     }
 
     @Transactional
-    public void generatePaymentKeys(YearMonth yearMonth, String userId) {
+    public void handleStudentPaymentProcessing(YearMonth yearMonth, String userId) {
         //paymentHistory 에 userId를 추가하여 외래키로 가지고 있음.
         List<PaymentHistory> paymentHistories = paymentHistoryRepository.findPaymentHistoriesWithUserIdAndYearMonth(userId, yearMonth);
         List<StudentGroup> studentGroups = studentGroupRepository.getStudentGroupsByUserId(userId);

--- a/src/main/java/com/edubill/edubillApi/service/StudentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/StudentService.java
@@ -24,7 +24,7 @@ public class StudentService {
         List<StudentGroup> studentGroups = studentGroupRepository.getStudentGroupsByUserId(userId);
         StudentGroup studentGroup = null;
         if (!studentGroups.isEmpty()) {
-            studentGroup = studentGroups.get(0); //TODO: studentGroup을 지정하지 않고 Academy에 모두 저장해야하는지 확인
+            studentGroup = studentGroups.get(0); //TODO: student_group이 여러개일 경우 한개만 선택하도록 student_group_id를 input 받도록 수정
         }
         else{
             studentGroup = StudentGroup.builder()


### PR DESCRIPTION
## Summary (작업사항)
동명이인인 학생과 아닌 학생을 분리하여 납부처리 로직이 다르게 작동

## 변경사유
하나의 메서드에 모두 담게 될 경우 복잡도 및 유지보수, 테스트에 용이하지 않다고 판단하여 로직을 분리.

## Reference (Wiki)

## 체크리스트
1. 테스트를 위해 5월과 6월에 해당하는 엑셀데이터를 분리하여 순차적으로 엔드포인트 접근
2. 결제키가 존재하지 않는 동명이인의 경우 수동처리 후 그 다음달 엑셀데이터 통해 자동분리되는지 검증
3. EB-47 브랜치에서는 studentPayment 객체 생성 여부는 처리하지 않고 있기 때문에 추후 rebase하여 수정 필요.

## 기타
근본적으로 동명이인 처리를 함에 있어 student 자체를 완벽히 구분하여 처리하는 것이 아닌 동일한 납부내역의 수와 동명이인 수가 같은 경우일 경우 모두 납부처리를 하는 방식이기 때문에 studentPayment 객체를 통해 특정 학생을 구분하여 생성할 수 없음.

예를 들어 동명이인인 학생 A와 학생 A'이 존재하고 5월 납부내역에 학생 A와 학생 A'에 해당하는 depositor가 모두 존재할 경우 동명이인 인원 수가 같기 때문에 자동납부처리를  할 수 있으나 납부데이터의 학생 A가 학생데이터의 학생A와 같은지 확인 은 불가능

해당 사항 확인한번 부탁드립니다.


@dlwlals1289