### PR TITLE
결제키 암호화/납부완료처리 시 studentPaymentHistory 객체 생성

### DIFF
--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -160,7 +160,7 @@ public class PaymentController {
     public ResponseEntity<HttpStatus> manualProcessingOfUnpaidHistory(@RequestBody UnpaidHistoryRequestDto unpaidHistoryRequestDto ){
        Long studentId = unpaidHistoryRequestDto.getStudentId();
        Long paymentHistoryId = unpaidHistoryRequestDto.getPaymentHistoryId();
-       String yearMonth = unpaidHistoryRequestDto.getYearMonth();
+       YearMonth yearMonth = unpaidHistoryRequestDto.getYearMonth();
 
        paymentService.manualProcessingOfUnpaidHistory(studentId, paymentHistoryId, yearMonth);
        return ResponseEntity.ok(HttpStatus.OK);

--- a/src/main/java/com/edubill/edubillApi/dto/payment/UnpaidHistoryRequestDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/payment/UnpaidHistoryRequestDto.java
@@ -2,6 +2,8 @@ package com.edubill.edubillApi.dto.payment;
 
 import lombok.*;
 
+import java.time.YearMonth;
+
 @Builder
 @Getter
 @AllArgsConstructor
@@ -12,5 +14,5 @@ public class UnpaidHistoryRequestDto {
 
     private Long paymentHistoryId;
 
-    private String yearMonth;
+    private YearMonth yearMonth;
 }

--- a/src/main/java/com/edubill/edubillApi/error/ErrorCode.java
+++ b/src/main/java/com/edubill/edubillApi/error/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
 
     //Payment
     PAYMENT_HISTORY_NOT_FOUND(400, "P001","납부내역이 존재하지 않습니다"),
+    PAYMENT_KEY_NOT_ENCRYPTED(500, "P002", "결제 키가 암호화되지 않았습니다"),
+
 
     // common
     INTERNAL_SERVER_ERROR(500, "C001", "서버 오류"),
@@ -34,6 +36,8 @@ public enum ErrorCode {
     INVALID_TYPE_VALUE(400, "C003", "잘못된 타입을 입력하였습니다."),
     BAD_CREDENTIALS(400, "C005", "bad credentials"),
     BAD_GATEWAY_ERROR(502,"C006", "bad gateway");
+    
+    //
 
 
 

--- a/src/main/java/com/edubill/edubillApi/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/edubill/edubillApi/error/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package com.edubill.edubillApi.error;
 
 import com.edubill.edubillApi.error.exception.BusinessException;
 
-import com.edubill.edubillApi.error.exception.UserAlreadyExistsException;
+import com.edubill.edubillApi.error.exception.PaymentKeyNotEncryptedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/edubill/edubillApi/error/exception/PaymentKeyNotEncryptedException.java
+++ b/src/main/java/com/edubill/edubillApi/error/exception/PaymentKeyNotEncryptedException.java
@@ -1,0 +1,9 @@
+package com.edubill.edubillApi.error.exception;
+
+import com.edubill.edubillApi.error.ErrorCode;
+
+public class PaymentKeyNotEncryptedException extends BusinessException {
+    public PaymentKeyNotEncryptedException(String message) {
+        super(message, ErrorCode.PAYMENT_KEY_NOT_ENCRYPTED);
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/jwt/JwtProvider.java
+++ b/src/main/java/com/edubill/edubillApi/jwt/JwtProvider.java
@@ -27,7 +27,7 @@ public class JwtProvider {
     private static final String AUTHORIZATION_KEY = "auth";
     // Token 식별자
     private static final String BEARER_PREFIX = "Bearer ";
-   private static final long ACCESS_TOKEN_TIME = 1000 * 60 * 30L; // 30 분
+    private static final long ACCESS_TOKEN_TIME = 1000 * 60 * 60 * 24L; // 24 시간
 
 
 

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -17,6 +17,7 @@ import com.edubill.edubillApi.repository.studentgroup.StudentGroupRepository;
 import com.edubill.edubillApi.utils.EncryptionUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -39,7 +40,8 @@ public class PaymentService {
     private final StudentRepository studentRepository;
     private final StudentPaymentRepository studentPaymentRepository;
 
-    private static final String SECRET_KEY = "1234567890123456"; // 16-byte key for AES
+    @Value("${payment.secret.key}")
+    private String SECRET_KEY; // 16-byte key for AES
 
     public void savePaymentHistories(List<PaymentHistory> paymentHistories) {
         paymentHistoryRepository.saveAll(paymentHistories);

--- a/src/main/java/com/edubill/edubillApi/utils/EncryptionUtils.java
+++ b/src/main/java/com/edubill/edubillApi/utils/EncryptionUtils.java
@@ -1,5 +1,7 @@
 package com.edubill.edubillApi.utils;
 
+import com.edubill.edubillApi.error.exception.PaymentKeyNotEncryptedException;
+
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Base64;

--- a/src/main/java/com/edubill/edubillApi/utils/EncryptionUtils.java
+++ b/src/main/java/com/edubill/edubillApi/utils/EncryptionUtils.java
@@ -1,0 +1,26 @@
+package com.edubill.edubillApi.utils;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+public class EncryptionUtils {
+    private static final String ALGORITHM = "AES";
+
+    public static String encrypt(String data, String secretKey) throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+        byte[] encryptedData = cipher.doFinal(data.getBytes());
+        return Base64.getEncoder().encodeToString(encryptedData);
+    }
+
+    public static String decrypt(String encryptedData, String secretKey) throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, keySpec);
+        byte[] decodedData = Base64.getDecoder().decode(encryptedData);
+        byte[] decryptedData = cipher.doFinal(decodedData);
+        return new String(decryptedData);
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,6 +6,7 @@ spring.datasource.username= ${EDUBILL_DB_USER}
 spring.datasource.password= ${EDUBILL_DB_PASSWORD}
 
 jwt.secret.key= ${JWT_SECRET_KEY}
+payment.secret.key=AbCdEfGhIjKlMnOp
 
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -32,5 +32,6 @@ spring.data.redis.port=6379
 spring.jpa.open-in-view=false
 
 jwt.secret.key=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
+payment.secret.key=AbCdEfGhIjKlMnOp
 
 validation.depositorNameRegex=".*[a-zA-Z].*"

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -6,6 +6,7 @@ spring.datasource.username= ${EDUBILL_DB_USER}
 spring.datasource.password= ${EDUBILL_DB_PASSWORD}
 
 jwt.secret.key= ${JWT_SECRET_KEY}
+payment.secret.key=AbCdEfGhIjKlMnOp
 
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=validate


### PR DESCRIPTION
## Summary (작업사항)
1. AES 를 이용해 대칭키 암호화 처리를 하였습니다.
2. createStudentPaymentHistory 메서드를 생성하여 납부완료처리 시 해당 학생 데이터에도 납부완료처리를 통해 미납입한 인원에 카운트되지 않도록 하였습니다.

## 변경사유

## Reference (Wiki)

## 체크리스트
1. studentPaymentHistory 객체를 생성하기 위해 코드를 refactoring 하는 과정에서 기존 작성해주신 manualProcessingOfUnpaidHistory() 를 통해 받은 요청데이터 중 yearMonth 속성의 타입을 String -> YearMonth 타입으로 변경하는 것이 적합하다고 판단하여 수정하였습니다. 확인해주시고 의견있으시면 알려주세요.
2. 지민님께서 작성해주신 base64를 이용한 인코딩은 단순히 인코딩일 뿐 암호화를 적용하지 않은 상태입니다. 따라서 이 부분 제가 결제키 암호화하면서 같이 수정하였습니다. 

## 기타
아직 학원비가 같은 동명이인에 대해 처리를 못했는데 아무리봐도 쉽지는 않은 것 같아 보류하였습니다.
이 부분이외에 모든 케이스에 대해는 정상적으로 동작하는 것 확인하였는데 실제 프론트와 연동해서 다시 한번 체크리스트 작성후 테스트하는게 좋을 것 같습니다.