### PR TITLE
미납내역 수동처리 시 납부내역 직접 입력

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis:3.2.3")
 	implementation("io.lettuce:lettuce-core:6.3.1.RELEASE")
 
+	//AWS SDK S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ dependencies {
 
 }
 
+tasks.withType(Test) {
+	environment 'S3_ACCESS_KEY', System.getenv('S3_ACCESS_KEY')
+	environment 'S3_SECRET_KEY', System.getenv('S3_SECRET_KEY')
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/src/main/java/com/edubill/edubillApi/config/S3Config.java
+++ b/src/main/java/com/edubill/edubillApi/config/S3Config.java
@@ -1,0 +1,39 @@
+package com.edubill.edubillApi.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class S3Config {
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private Regions region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -171,11 +171,11 @@ public class PaymentController {
     @Operation(summary = "미납 내역 수동처리 - 납부내역 직접 입력",
             description = "수동으로 완납처리 시 납부내역을 직접 입력하여 연결한다..")
     @PutMapping("/manualProcessing/input")
-    public ResponseEntity<HttpStatus> manualProcessingOfUnpaidHistoryByManualInput(
+    public ResponseEntity<String> manualProcessingOfUnpaidHistoryByManualInput(
             @RequestBody ManualPaymentHistoryRequestDto manualPaymentHistoryRequestDto,
             @RequestPart MultipartFile multipartFile){
 
         paymentService.manualProcessingOfUnpaidHistoryByManualInput(manualPaymentHistoryRequestDto, multipartFile);
-        return ResponseEntity.ok(HttpStatus.OK);
+        return ResponseEntity.ok("납부내역 생성 완료");
     }
 }

--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package com.edubill.edubillApi.controller;
 
+import com.edubill.edubillApi.domain.PaymentType;
 import com.edubill.edubillApi.dto.payment.*;
 import com.edubill.edubillApi.excel.ExcelService;
 import com.edubill.edubillApi.service.PaymentService;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
 import java.time.YearMonth;
@@ -82,7 +84,7 @@ public class PaymentController {
                             example = "10",
                             schema = @Schema(type = "integer", defaultValue = "10"))
             })
-    public ResponseEntity<Page<PaymentHistoryResponse>> getPaidHistories(
+    public ResponseEntity<Page<PaymentHistoryResponseDto>> getPaidHistories(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @PathVariable(name = "yearMonth") YearMonth yearMonth,
@@ -114,7 +116,7 @@ public class PaymentController {
                             example = "10",
                             schema = @Schema(type = "integer", defaultValue = "10"))
             })
-    public ResponseEntity<Page<PaymentHistoryResponse>> getUnpaidHistories(
+    public ResponseEntity<Page<PaymentHistoryResponseDto>> getUnpaidHistories(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @PathVariable(name = "yearMonth") YearMonth yearMonth,
@@ -164,5 +166,16 @@ public class PaymentController {
 
        paymentService.manualProcessingOfUnpaidHistory(studentId, paymentHistoryId, yearMonth);
        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    @Operation(summary = "미납 내역 수동처리 - 납부내역 직접 입력",
+            description = "수동으로 완납처리 시 납부내역을 직접 입력하여 연결한다..")
+    @PutMapping("/manualProcessing/input")
+    public ResponseEntity<HttpStatus> manualProcessingOfUnpaidHistoryByManualInput(
+            @RequestBody ManualPaymentHistoryRequestDto manualPaymentHistoryRequestDto,
+            @RequestPart MultipartFile multipartFile){
+
+        paymentService.manualProcessingOfUnpaidHistoryByManualInput(manualPaymentHistoryRequestDto, multipartFile);
+        return ResponseEntity.ok(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -169,11 +169,11 @@ public class PaymentController {
     }
 
     @Operation(summary = "미납 내역 수동처리 - 납부내역 직접 입력",
-            description = "수동으로 완납처리 시 납부내역을 직접 입력하여 연결한다..")
+            description = "수동으로 완납처리 시 납부내역을 직접 입력하여 연결한다.")
     @PutMapping("/manualProcessing/input")
     public ResponseEntity<String> manualProcessingOfUnpaidHistoryByManualInput(
             @RequestBody ManualPaymentHistoryRequestDto manualPaymentHistoryRequestDto,
-            @RequestPart MultipartFile multipartFile){
+            @RequestPart("file") MultipartFile multipartFile){
 
         paymentService.manualProcessingOfUnpaidHistoryByManualInput(manualPaymentHistoryRequestDto, multipartFile);
         return ResponseEntity.ok("납부내역 생성 완료");

--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.edubill.edubillApi.controller;
 
 import com.edubill.edubillApi.domain.PaymentType;
+import com.edubill.edubillApi.dto.FileUrlResponseDto;
 import com.edubill.edubillApi.dto.payment.*;
 import com.edubill.edubillApi.excel.ExcelService;
 import com.edubill.edubillApi.service.PaymentService;
@@ -20,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.security.Principal;
 import java.time.YearMonth;
 
@@ -171,11 +173,10 @@ public class PaymentController {
     @Operation(summary = "미납 내역 수동처리 - 납부내역 직접 입력",
             description = "수동으로 완납처리 시 납부내역을 직접 입력하여 연결한다.")
     @PutMapping("/manualProcessing/input")
-    public ResponseEntity<String> manualProcessingOfUnpaidHistoryByManualInput(
-            @RequestBody ManualPaymentHistoryRequestDto manualPaymentHistoryRequestDto,
-            @RequestPart("file") MultipartFile multipartFile){
+    public ResponseEntity<FileUrlResponseDto> manualProcessingOfUnpaidHistoryByManualInput(
+            @ModelAttribute ManualPaymentHistoryRequestDto manualPaymentHistoryRequestDto) throws IOException {
 
-        paymentService.manualProcessingOfUnpaidHistoryByManualInput(manualPaymentHistoryRequestDto, multipartFile);
-        return ResponseEntity.ok("납부내역 생성 완료");
+        FileUrlResponseDto fileUrlResponseDto = paymentService.manualProcessingOfUnpaidHistoryByManualInput(manualPaymentHistoryRequestDto);
+        return ResponseEntity.ok(fileUrlResponseDto);
     }
 }

--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -174,6 +174,7 @@ public class PaymentController {
             description = "수동으로 완납처리 시 납부내역을 직접 입력하여 연결한다.")
     @PutMapping("/manualProcessing/input")
     public ResponseEntity<FileUrlResponseDto> manualProcessingOfUnpaidHistoryByManualInput(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수동 납부내역 입력 요청", content = @Content(mediaType = "multipart/form-data", schema = @Schema(implementation = ManualPaymentHistoryRequestDto.class)))
             @ModelAttribute ManualPaymentHistoryRequestDto manualPaymentHistoryRequestDto) throws IOException {
 
         FileUrlResponseDto fileUrlResponseDto = paymentService.manualProcessingOfUnpaidHistoryByManualInput(manualPaymentHistoryRequestDto);

--- a/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
+++ b/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
@@ -50,8 +50,7 @@ public class PaymentHistory extends BaseEntity {
     @Builder.Default
     private PaymentStatus paymentStatus = PaymentStatus.UNPAID; //납부확인 유무
 
-    @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "student_payment_history_id")
+    @OneToOne(mappedBy = "paymentHistory")
     private StudentPaymentHistory studentPaymentHistory;
 
 

--- a/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
+++ b/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
@@ -43,6 +43,9 @@ public class PaymentHistory extends BaseEntity {
     @Column(name = "manager_id")
     private String managerId;
 
+    @Column(name = "s3_url")
+    private String s3Url;
+
     @Enumerated(EnumType.STRING)
     private PaymentType paymentType; //거래방식
 

--- a/src/main/java/com/edubill/edubillApi/domain/PaymentType.java
+++ b/src/main/java/com/edubill/edubillApi/domain/PaymentType.java
@@ -5,13 +5,25 @@ import lombok.Getter;
 @Getter
 public enum PaymentType {
 
-    CASH("현금"),
-    CREDIT_CARD("신용카드"),
-    BANK_TRANSFER("계좌이체");
+    CASH("현금결제"),
+    CREDIT_CARD("카드결제"),
+    KAKAO("카톡송금"),
+    GIFT_VOUCHER("지역상품권"),
+    BANK_TRANSFER("계좌이체"),
+    ETC("기타");
 
     private final String paymentTypeDescription;
 
     PaymentType(String paymentTypeDescription) {
         this.paymentTypeDescription = paymentTypeDescription;
+    }
+
+    public static PaymentType getPaymentTypeByDescription(String description) {
+        for (PaymentType type : PaymentType.values()) {
+            if (type.getPaymentTypeDescription().equals(description)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("No matching PaymentType for description: " + description);
     }
 }

--- a/src/main/java/com/edubill/edubillApi/domain/StudentPaymentHistory.java
+++ b/src/main/java/com/edubill/edubillApi/domain/StudentPaymentHistory.java
@@ -1,9 +1,11 @@
 package com.edubill.edubillApi.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.parameters.P;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -11,6 +13,8 @@ import static jakarta.persistence.FetchType.LAZY;
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
 @Table(name = "STUDENT_PAYMENT_HISTORY", uniqueConstraints = @UniqueConstraint(columnNames = {"student_id", "paymentHistory_id"}))
 public class StudentPaymentHistory extends BaseEntity{
 
@@ -20,11 +24,11 @@ public class StudentPaymentHistory extends BaseEntity{
     private Long studentPaymentHistoryId;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "student_id", insertable = false, updatable = false)
+    @JoinColumn(name = "student_id")
     private Student student;
 
     @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "paymentHistory_id", insertable = false, updatable = false)
+    @JoinColumn(name = "paymentHistory_id")
     private PaymentHistory paymentHistory;
 
     @Column(name = "year_month_str")
@@ -39,13 +43,5 @@ public class StudentPaymentHistory extends BaseEntity{
     public void setPaymentHistory(PaymentHistory paymentHistory) {
         this.paymentHistory = paymentHistory;
         paymentHistory.toBuilder().studentPaymentHistory(this);
-    }
-
-    @Builder
-    public StudentPaymentHistory(Student student, PaymentHistory paymentHistory, String yearMonth)
-    {
-        this.student = student;
-        this.paymentHistory = paymentHistory;
-        this.yearMonth = yearMonth;
     }
 }

--- a/src/main/java/com/edubill/edubillApi/dto/FileUrlResponseDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/FileUrlResponseDto.java
@@ -1,0 +1,11 @@
+package com.edubill.edubillApi.dto;
+
+import lombok.*;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FileUrlResponseDto {
+    private String s3URL;
+}

--- a/src/main/java/com/edubill/edubillApi/dto/payment/ManualPaymentHistoryRequestDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/payment/ManualPaymentHistoryRequestDto.java
@@ -2,6 +2,8 @@ package com.edubill.edubillApi.dto.payment;
 
 import com.edubill.edubillApi.domain.PaymentType;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,12 +16,21 @@ import java.time.YearMonth;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ManualPaymentHistoryRequestDto {
 
+    @Schema(description = "학생 ID를 입력한다.", type = "integer", format = "int64", example = "1")
     private Long studentId;
+
+    @Schema(description = "연도-월", type = "String", format = "yearMonth", example = "2024-05")
     private YearMonth yearMonth;
 
-    private String paymentTypeString; //거래방식
-    private Integer paidAmount;
-    private String memo;  // 메모
+    @Schema(description = "거래유형을 입력한다.", type = "String", example = "현금결제")
+    private String paymentTypeString;
 
+    @Schema(description = "거래금액을 입력한다.", type = "integer", format = "int32", example = "3000000")
+    private Integer paidAmount;
+
+    @Schema(description = "메모를 입력한다.", type = "String", example = "수동입력처리")
+    private String memo;
+
+    @Schema(description = "증빙서류를 업로드한다.", format = "binary")
     private MultipartFile file;
 }

--- a/src/main/java/com/edubill/edubillApi/dto/payment/ManualPaymentHistoryRequestDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/payment/ManualPaymentHistoryRequestDto.java
@@ -1,0 +1,23 @@
+package com.edubill.edubillApi.dto.payment;
+
+import com.edubill.edubillApi.domain.PaymentType;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.YearMonth;
+
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManualPaymentHistoryRequestDto {
+
+    private Long studentId;
+    private YearMonth yearMonth;
+
+    private String paymentTypeString; //거래방식
+    private Integer paidAmount;
+    private String memo;  // 메모
+}

--- a/src/main/java/com/edubill/edubillApi/dto/payment/ManualPaymentHistoryRequestDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/payment/ManualPaymentHistoryRequestDto.java
@@ -20,4 +20,6 @@ public class ManualPaymentHistoryRequestDto {
     private String paymentTypeString; //거래방식
     private Integer paidAmount;
     private String memo;  // 메모
+
+    private MultipartFile file;
 }

--- a/src/main/java/com/edubill/edubillApi/dto/payment/PaymentHistoryResponseDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/payment/PaymentHistoryResponseDto.java
@@ -2,7 +2,7 @@ package com.edubill.edubillApi.dto.payment;
 
 import java.time.LocalDateTime;
 
-public record PaymentHistoryResponse(
+public record PaymentHistoryResponseDto(
         Long paymentHistoryId,
         String studentName,
 

--- a/src/main/java/com/edubill/edubillApi/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/edubill/edubillApi/error/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindException;
 
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 
 import static com.edubill.edubillApi.error.ErrorCode.*;
@@ -47,5 +48,11 @@ public class GlobalExceptionHandler {
         log.error("Exception: ", e);
         final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<?> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        String errorMessage = "File size exceeds limit. Please upload a smaller file." + e.getMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
     }
 }

--- a/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryRepository.java
@@ -1,8 +1,7 @@
 package com.edubill.edubillApi.repository;
 
-import com.edubill.edubillApi.domain.ExcelUploadStatus;
 import com.edubill.edubillApi.domain.StudentPaymentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudentPaymentRepository extends JpaRepository<StudentPaymentHistory, Long> {
+public interface StudentPaymentHistoryRepository extends JpaRepository<StudentPaymentHistory, Long> {
 }

--- a/src/main/java/com/edubill/edubillApi/service/FileUploadService.java
+++ b/src/main/java/com/edubill/edubillApi/service/FileUploadService.java
@@ -1,0 +1,45 @@
+package com.edubill.edubillApi.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.edubill.edubillApi.config.S3Config;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FileUploadService {
+
+    private final S3Config s3Config;
+
+    public String saveImageFile(MultipartFile file) throws IOException {
+        //uploadPath 생성
+        String originalFilename = file.getOriginalFilename();
+        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        String uploadFilename = UUID.randomUUID() + "." + fileExtension;
+
+        log.info("File upload started: " + uploadFilename);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+
+        AmazonS3Client amazonS3Client = s3Config.amazonS3Client();
+        String bucketName = s3Config.getBucketName();
+
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucketName, uploadFilename, file.getInputStream(), objectMetadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+        //ex) https://edubill-prd.s3.ap-northeast-2.amazonaws.com/<uploadPath>
+        return amazonS3Client.getUrl(bucketName, uploadFilename).toString();
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -281,6 +281,8 @@ public class PaymentService {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 유저입니다.  userId: " + studentId));
 
+        String s3Url = saveImageFile(manualPaymentHistoryRequestDto.getFile());
+
         PaymentHistory newPaymentHistory = paymentHistoryRepository.save(PaymentHistory.builder()
                 .depositDate(LocalDateTime.now())
                 .bankName("수동입력")
@@ -288,7 +290,9 @@ public class PaymentService {
                 .memo(manualPaymentHistoryRequestDto.getMemo())
                 .paymentType(paymentType)
                 .managerId(userId)
+                .s3Url(s3Url)
                 .build());
+
 
         paymentStatusToPaid(student, newPaymentHistory);
         createStudentPaymentHistory(student, newPaymentHistory, yearMonth);
@@ -306,7 +310,9 @@ public class PaymentService {
                 .student(student)
                 .build());
 
-        String s3Url = saveImageFile(manualPaymentHistoryRequestDto.getFile());
+
+
+
         return new FileUrlResponseDto(s3Url);
     }
 
@@ -331,8 +337,6 @@ public class PaymentService {
         );
         //ex) https://edubill-prd.s3.ap-northeast-2.amazonaws.com/<uploadPath>
         return amazonS3Client.getUrl(bucketName, uploadFilename).toString();
-
-        //TODO: db에 s3 url 저장
     }
 
     public MemoResponseDto updateMemo(MemoRequestDto memoRequestDto) {

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -274,7 +274,7 @@ public class PaymentService {
 
         PaymentHistory newPaymentHistory = paymentHistoryRepository.save(PaymentHistory.builder()
                 .depositDate(LocalDateTime.now())
-                .bankName("은행")
+                .bankName("수동입력")
                 .paidAmount(manualPaymentHistoryRequestDto.getPaidAmount())
                 .memo(manualPaymentHistoryRequestDto.getMemo())
                 .paymentType(PaymentType.getPaymentTypeByDescription(manualPaymentHistoryRequestDto.getPaymentTypeString()))

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,23 +1,39 @@
 spring.config.activate.on-profile=dev
 
+#DB
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mariadb://${EDUBILL_DB_HOST}:3306/edubilldev?useBulkStmts=false
 spring.datasource.username= ${EDUBILL_DB_USER}
 spring.datasource.password= ${EDUBILL_DB_PASSWORD}
-
-jwt.secret.key= ${JWT_SECRET_KEY}
-payment.secret.key=AbCdEfGhIjKlMnOp
-
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=validate
 
+#flyway
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration
 
+#redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
-spring.jpa.open-in-view=false
+#jwt
+jwt.secret.key= ${JWT_SECRET_KEY}
 
+#paymentKey \uC554\uD638\uD654 \uD0A4
+payment.secret.key=AbCdEfGhIjKlMnOp
+
+#S3
+cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
+cloud.aws.s3.bucketName=edubill-imagefile-prd
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
+
+#multipartFile
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.resolve-lazily=true
+#\uAE30\uD0C0
+spring.jpa.open-in-view=false
 validation.depositorNameRegex=".*[a-zA-Z].*"

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,5 +1,6 @@
 spring.config.activate.on-profile=local
 
+#DB
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mariadb://${EDUBILL_DB_HOST}:3306/edubill?useBulkStmts=false
 spring.datasource.username=${EDUBILL_DB_USER}
@@ -7,31 +8,43 @@ spring.datasource.password=${EDUBILL_DB_PASSWORD}
 
 #jdbcTemplate sql log
 logging.level.org.springframework.jdbc=debug
-
 #JPA log
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
-
-# 1. SQL logging
+#SQL logging
 logging.level.org.hibernate.SQL=DEBUG
-
-# 2. SQL formatting
+#SQL formatting
 spring.jpa.properties.hibernate.format_sql=true
-
-# 3. DDL
+#DDL
 spring.jpa.hibernate.ddl-auto=validate
 
-# flyway info
+#flyway
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=1
 spring.flyway.locations=classpath:db/migration
 
+#redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
-spring.jpa.open-in-view=false
+#jwt
+jwt.secret.key=${JWT_SECRET_KEY}
 
-jwt.secret.key=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
+#paymentKey \uC554\uD638\uD654 \uD0A4
 payment.secret.key=AbCdEfGhIjKlMnOp
 
+#S3
+cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
+cloud.aws.s3.bucketName=edubill-imagefile-prd
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
+
+#multipartFile
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.resolve-lazily=true
+
+#\uAE30\uD0C0
 validation.depositorNameRegex=".*[a-zA-Z].*"
+spring.jpa.open-in-view=false

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,23 +1,40 @@
 spring.config.activate.on-profile=prod
 
+#DB
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mariadb://${EDUBILL_DB_HOST}:3306/edubill?useBulkStmts=false
 spring.datasource.username= ${EDUBILL_DB_USER}
 spring.datasource.password= ${EDUBILL_DB_PASSWORD}
-
-jwt.secret.key= ${JWT_SECRET_KEY}
-payment.secret.key=AbCdEfGhIjKlMnOp
-
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=validate
 
+#flyway
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration
 
+#redis
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
-spring.jpa.open-in-view=false
+#jwt
+jwt.secret.key= ${JWT_SECRET_KEY}
 
+#paymentKey \uC554\uD638\uD654 \uD0A4
+payment.secret.key=AbCdEfGhIjKlMnOp
+
+#S3
+cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
+cloud.aws.s3.bucketName=edubill-imagefile-prd
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
+
+#multipartFile
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.resolve-lazily=true
+
+#\uAE30\uD0C0
+spring.jpa.open-in-view=false
 validation.depositorNameRegex=".*[a-zA-Z].*"

--- a/src/main/resources/db/migration/V1202406282044__delete_studentpaymenthistory_id.sql
+++ b/src/main/resources/db/migration/V1202406282044__delete_studentpaymenthistory_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE students
+    DROP COLUMN student_payment_history_id;
+
+ALTER TABLE payment_history
+    DROP COLUMN student_payment_history_id;

--- a/src/main/resources/db/migration/V1202406282046__update_studentpaymenthistory_table.sql
+++ b/src/main/resources/db/migration/V1202406282046__update_studentpaymenthistory_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS student_payment_history
+    ADD CONSTRAINT UKjjq15eoqs9qp7721wqpqdj8kq UNIQUE (student_id, payment_history_id),
+    ADD CONSTRAINT UK_ktohn1q0e43hjfv3uis5svhk0 UNIQUE (payment_history_id),
+    ADD CONSTRAINT FK2lwbkvot1hyluov2rdtplgyre FOREIGN KEY (payment_history_id) REFERENCES payment_history (payment_history_id),
+    ADD CONSTRAINT FKnd0fwxjok1qu1ylmg4th994b4 FOREIGN KEY (student_id) REFERENCES students (student_id);

--- a/src/main/resources/db/migration/V1202406291120__add_s3url_column.sql
+++ b/src/main/resources/db/migration/V1202406291120__add_s3url_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payment_history
+    ADD COLUMN s3_url VARCHAR(255);

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -7,8 +7,6 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
 # 1-1. logger \uC0AC\uC6A9
 logging.level.org.hibernate.SQL=DEBUG
-# 1-2. System.out \uC0AC\uC6A9
-# spring.jpa.show-sql=true
 
 # 2. SQL \uAC00\uB3C5\uC131 \uC99D\uAC00
 spring.jpa.properties.hibernate.format_sql=true
@@ -20,8 +18,18 @@ spring.jpa.hibernate.ddl-auto=update
 #flyway info
 spring.flyway.enabled=false
 
-#secret key
-jwt.secret.key=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
-payment.secret.key=AbCdEfGhIjKlMnOp
+#S3
+cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
+cloud.aws.s3.bucketName=edubill-imagefile-prd
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
 
+#multipartFile
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.resolve-lazily=true
+
+jwt.secret.key=rkGU45258GGhiolLO2465TFY5345kGU45258GGhiolLO2465TFY534
+payment.secret.key=AbCdEfGhIjKlMnOp
 validation.depositorNameRegex=".*[a-zA-Z].*"

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,17 +1,7 @@
-
-#jdbcTemplate sql log
 logging.level.org.springframework.jdbc=debug
-
-#JPA log
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
-
-# 1-1. logger \uC0AC\uC6A9
 logging.level.org.hibernate.SQL=DEBUG
-
-# 2. SQL \uAC00\uB3C5\uC131 \uC99D\uAC00
 spring.jpa.properties.hibernate.format_sql=true
-
-# 3. DDL(create, alter, drop)\uC744 \uD1B5\uD574 db\uC0DD\uC131
 spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=update
 


### PR DESCRIPTION
## Summary (작업사항)
미확인내역에 대해 수동처리를 할때, 납부내역을 직접 입력하여 등록하도록 한다.

## 변경사유

## Reference (Wiki)

## 체크리스트
Payment_history객체를 생성해야하지만, bankName, depositeDate은 알 수가 없는 상태입니다.
따라서 bankName에는 수동으로 등록하였음을 확인할 수 있도록 "수동입력"이라는 값을 저장하도록 하였고 depositeDate의 경우 학원원장이 납부내역을 직접 생성한 날짜를 저장할 수 있도록 LocalDateTime.now() 함수를 사용하였습니다.

## 기타
1. 납부내역을 직접생성할때, 증명자료 (사진)을 입력받도록 되어있습니다. 해당 파일을 MultipartFile 형태로 업로드 받게 되면 S3에 저장하여 해당 S3의 URL만을 db에 저장해야합니다. 하지만 현재 S3에는 github action을 통해 실행파일을 배포하여 저장하고 있어서 버켓을 추가적으로 사용가능해도 비용이 부과과 되지 않는지 확인해봐야 할 것 같습니다.

2. 직접입력 후 확인버튼을 누르게 될 경우 그 다음 화면이 존재하지 않습니다. 해당 버튼을 누르면 미확인내역을 redirection 해서 매번 갱신하는 방향이지 않을까 싶습니다.
