### PR TITLE
Parameter의 format, type의 mismatch가 발생했을때 적절한 error response를 반환

### DIFF
--- a/src/main/java/com/edubill/edubillApi/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/edubill/edubillApi/error/GlobalExceptionHandler.java
@@ -7,12 +7,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+
+import java.time.format.DateTimeParseException;
 
 import static com.edubill.edubillApi.error.ErrorCode.*;
 
@@ -48,6 +55,43 @@ public class GlobalExceptionHandler {
         log.error("Exception: ", e);
         final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    //PathVariable 이나 RequestParameter으로 입력받은 타입이 옳지 않을때
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String errorMessage = "Invalid parameter type : " + ex.getName();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+    }
+
+    // 날짜 타입이 알맞지 않을때
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<?> handleDateTimeParseException(DateTimeParseException ex) {
+        String errorMessage = "Invalid date format: " + ex.getParsedString() + ". Expected format is YYYY-MM.";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+    }
+
+    // 쿼리파라미터에 값이 할당되지 않았을때
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<?> handleMissingServletRequestParameter(MissingServletRequestParameterException ex) {
+        String errorMessage = "Required request parameter '" + ex.getParameterName() + "' is not present.";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+    }
+
+    // Content-Type 이 일치하지 않을때
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    public ResponseEntity<String> handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException ex) {
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                .body("Unsupported media type: " + ex.getContentType());
+    }
+
+    //입력받는 데이터가 json 형태가 아닐때
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body("Invalid request body: " + ex.getMessage());
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)


### PR DESCRIPTION
## Summary (작업사항)
프론트 측의 요청으로 Parameter가 적절한 타입이 아니거나 포멧이 다를 경우 프론트에서 확인하기 쉽도록 error response를 전달한다.

## 변경사유

## Reference (Wiki)

## 체크리스트
GlobalExceptionHandler 클래스에 추가한 6개의 메서드를 중심으로 확인해주시면 좋을 것 같습니다.
모든 에러를 다 처리할 수 없어 필요한 에러가 발견되면 추가할 예정입니다.

## 기타
