### PR TITLE
PaymentHistory, PaymentKey, StudentPaymentHistory 객체 삭제 API

### DIFF
--- a/src/main/java/com/edubill/edubillApi/controller/TestController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/TestController.java
@@ -27,18 +27,13 @@ public class TestController {
     @DeleteMapping("/deletePaymentHistory/{yearMonth}")
     public ResponseEntity<String> deletePaymentData(@PathVariable(name = "yearMonth") YearMonth yearMonth) {
         String userId = SecurityUtils.getCurrentUserId();
-
         // 1.삭제할 studentId 찾기
         List<Long> studentIds = studentPaymentHistoryRepository.findStudentIdsByUserIdAndYearMonth(userId, yearMonth);
-
         // 2.PaymentHistory, StudentPaymentHistory 객체 삭제
         long deletedPaymentHistoryCount = paymentHistoryRepository.deleteByUserIdAndYearMonth(userId, yearMonth);
-
         // 3.PaymentKey 객체 삭제
         long deletedPaymentKeys = paymentKeyRepository.deleteByStudentIds(studentIds);
 
-
-
-        return ResponseEntity.ok("Payment data deleted successfully.");
+        return ResponseEntity.ok("Deleted excel data: " + deletedPaymentHistoryCount + "\nDeleted payment keys: " + deletedPaymentKeys);
     }
 }

--- a/src/main/java/com/edubill/edubillApi/controller/TestController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/TestController.java
@@ -1,0 +1,44 @@
+package com.edubill.edubillApi.controller;
+
+import com.edubill.edubillApi.repository.StudentPaymentHistoryRepository;
+import com.edubill.edubillApi.repository.payment.PaymentHistoryRepository;
+import com.edubill.edubillApi.repository.payment.PaymentKeyCustomRepository;
+import com.edubill.edubillApi.repository.payment.PaymentKeyRepository;
+import com.edubill.edubillApi.utils.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/test")
+@RequiredArgsConstructor
+@Slf4j
+public class TestController {
+
+    private final PaymentKeyRepository paymentKeyRepository;
+    private final PaymentHistoryRepository paymentHistoryRepository;
+    private final StudentPaymentHistoryRepository studentPaymentHistoryRepository;
+
+    @DeleteMapping("/deletePaymentHistory/{yearMonth}")
+    public ResponseEntity<String> deletePaymentData(@PathVariable(name = "yearMonth") YearMonth yearMonth) {
+        String userId = SecurityUtils.getCurrentUserId();
+
+        // 1.삭제할 studentId 찾기
+        List<Long> studentIds = studentPaymentHistoryRepository.findStudentIdsByUserIdAndYearMonth(userId, yearMonth);
+
+        // 2.PaymentHistory, StudentPaymentHistory 객체 삭제
+        long deletedPaymentHistoryCount = paymentHistoryRepository.deleteByUserIdAndYearMonth(userId, yearMonth);
+
+        // 3.PaymentKey 객체 삭제
+        long deletedPaymentKeys = paymentKeyRepository.deleteByStudentIds(studentIds);
+
+
+
+        return ResponseEntity.ok("Payment data deleted successfully.");
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
+++ b/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
@@ -53,7 +53,7 @@ public class PaymentHistory extends BaseEntity {
     @Builder.Default
     private PaymentStatus paymentStatus = PaymentStatus.UNPAID; //납부확인 유무
 
-    @OneToOne(mappedBy = "paymentHistory")
+    @OneToOne(mappedBy = "paymentHistory", cascade = CascadeType.ALL, orphanRemoval = true)
     private StudentPaymentHistory studentPaymentHistory;
 
 

--- a/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
+++ b/src/main/java/com/edubill/edubillApi/domain/PaymentHistory.java
@@ -53,7 +53,7 @@ public class PaymentHistory extends BaseEntity {
     @Builder.Default
     private PaymentStatus paymentStatus = PaymentStatus.UNPAID; //납부확인 유무
 
-    @OneToOne(mappedBy = "paymentHistory", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "paymentHistory")
     private StudentPaymentHistory studentPaymentHistory;
 
 

--- a/src/main/java/com/edubill/edubillApi/domain/StudentPaymentHistory.java
+++ b/src/main/java/com/edubill/edubillApi/domain/StudentPaymentHistory.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.security.core.parameters.P;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -29,6 +31,7 @@ public class StudentPaymentHistory extends BaseEntity{
 
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "paymentHistory_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private PaymentHistory paymentHistory;
 
     @Column(name = "year_month_str")

--- a/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryCustomRepository.java
@@ -1,0 +1,8 @@
+package com.edubill.edubillApi.repository;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public interface StudentPaymentHistoryCustomRepository {
+    List<Long> findStudentIdsByUserIdAndYearMonth(String userId, YearMonth yearMonth);
+}

--- a/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryCustomRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.edubill.edubillApi.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+import static com.edubill.edubillApi.domain.QStudentPaymentHistory.studentPaymentHistory;
+
+@Repository
+@RequiredArgsConstructor
+public class StudentPaymentHistoryCustomRepositoryImpl implements StudentPaymentHistoryCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Long> findStudentIdsByUserIdAndYearMonth(String userId, YearMonth yearMonth) {
+        LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999);
+
+        // 삭제된 paymentHistory에 해당하는 student_id들을 조회
+        return queryFactory
+                .select(studentPaymentHistory.student.id)
+                .from(studentPaymentHistory)
+                .where(studentPaymentHistory.paymentHistory.managerId.eq(userId)
+                        .and(studentPaymentHistory.paymentHistory.depositDate.between(startDateTime, endDateTime)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryCustomRepositoryImpl.java
@@ -20,15 +20,12 @@ public class StudentPaymentHistoryCustomRepositoryImpl implements StudentPayment
     @Override
     @Transactional(readOnly = true)
     public List<Long> findStudentIdsByUserIdAndYearMonth(String userId, YearMonth yearMonth) {
-        LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
-        LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999);
-
         // 삭제된 paymentHistory에 해당하는 student_id들을 조회
         return queryFactory
                 .select(studentPaymentHistory.student.id)
                 .from(studentPaymentHistory)
                 .where(studentPaymentHistory.paymentHistory.managerId.eq(userId)
-                        .and(studentPaymentHistory.paymentHistory.depositDate.between(startDateTime, endDateTime)))
+                        .and(studentPaymentHistory.yearMonth.eq(String.valueOf(yearMonth))))
                 .fetch();
     }
 }

--- a/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/StudentPaymentHistoryRepository.java
@@ -3,5 +3,7 @@ package com.edubill.edubillApi.repository;
 import com.edubill.edubillApi.domain.StudentPaymentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudentPaymentHistoryRepository extends JpaRepository<StudentPaymentHistory, Long> {
+import java.time.YearMonth;
+
+public interface StudentPaymentHistoryRepository extends JpaRepository<StudentPaymentHistory, Long>, StudentPaymentHistoryCustomRepository{
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
@@ -21,4 +21,6 @@ public interface PaymentHistoryCustomRepository {
     List<PaymentHistory> findPaymentHistoriesWithUserIdAndYearMonth(String managerId, YearMonth yearMonth);
 
     long countPaidUserGroupsForUserInMonth(String userId, YearMonth yearMonth);
+
+    long deleteByUserIdAndYearMonth(String userId, YearMonth yearMonth);
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.edubill.edubillApi.repository.payment;
 import com.edubill.edubillApi.domain.PaymentHistory;
 import com.edubill.edubillApi.domain.PaymentStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -138,5 +139,18 @@ public class PaymentHistoryCustomRepositoryImpl implements PaymentHistoryCustomR
                         .and(paymentHistory.depositDate.between(startDateTime, endDateTime)))
                 .where(studentGroup.managerId.eq(managerId))
                 .fetchCount();
+    }
+
+    @Override
+    @Transactional
+    public long deleteByUserIdAndYearMonth(String userId, YearMonth yearMonth) {
+        LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999);
+
+        return queryFactory
+                .delete(paymentHistory)
+                .where(paymentHistory.managerId.eq(userId)
+                        .and(paymentHistory.depositDate.between(startDateTime, endDateTime)))
+                .execute();
     }
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentKeyCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentKeyCustomRepository.java
@@ -1,0 +1,7 @@
+package com.edubill.edubillApi.repository.payment;
+
+import java.util.List;
+
+public interface PaymentKeyCustomRepository {
+    long deleteByStudentIds(List<Long> studentIds);
+}

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentKeyCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentKeyCustomRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.edubill.edubillApi.repository.payment;
+
+import com.edubill.edubillApi.domain.QPaymentKey;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentKeyCustomRepositoryImpl implements PaymentKeyCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+    @Override
+    @Transactional
+    public long deleteByStudentIds(List<Long> studentIds) {
+
+        QPaymentKey paymentKey = QPaymentKey.paymentKey1;
+
+        return queryFactory.delete(paymentKey)
+                .where(paymentKey.student.id.in(studentIds))
+                .execute();
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentKeyRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentKeyRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface PaymentKeyRepository extends JpaRepository<PaymentKey, Long> {
+public interface PaymentKeyRepository extends JpaRepository<PaymentKey, Long>, PaymentKeyCustomRepository {
     List<PaymentKey> findAllByStudent(Student student);
 }

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -1,10 +1,5 @@
 package com.edubill.edubillApi.service;
 
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.edubill.edubillApi.config.S3Config;
 import com.edubill.edubillApi.domain.*;
 import com.edubill.edubillApi.dto.FileUrlResponseDto;
 import com.edubill.edubillApi.dto.payment.*;
@@ -17,6 +12,7 @@ import com.edubill.edubillApi.error.exception.PaymentKeyNotEncryptedException;
 import com.edubill.edubillApi.error.exception.UserNotFoundException;
 import com.edubill.edubillApi.repository.StudentPaymentHistoryRepository;
 import com.edubill.edubillApi.repository.payment.PaymentHistoryRepository;
+import com.edubill.edubillApi.repository.payment.PaymentKeyCustomRepository;
 import com.edubill.edubillApi.repository.payment.PaymentKeyRepository;
 import com.edubill.edubillApi.repository.student.StudentRepository;
 import com.edubill.edubillApi.repository.studentgroup.StudentGroupRepository;

--- a/src/main/resources/db/migration/V1202407100004__add_cascade_in_studentpaymenthistory_table.sql
+++ b/src/main/resources/db/migration/V1202407100004__add_cascade_in_studentpaymenthistory_table.sql
@@ -1,5 +1,9 @@
+ALTER TABLE student_payment_history
+    DROP FOREIGN KEY IF EXISTS FK2lwbkvot1hyluov2rdtplgyre;
+
+
 alter table if exists student_payment_history
-    add constraint FK_my_custom_fk_name
+    add constraint FK2lwbkvot1hyluov2rdtplgyre
     foreign key (payment_history_id)
     references payment_history (payment_history_id)
-    on delete cascade
+    on delete cascade;

--- a/src/main/resources/db/migration/V1202407100004__add_cascade_in_studentpaymenthistory_table.sql
+++ b/src/main/resources/db/migration/V1202407100004__add_cascade_in_studentpaymenthistory_table.sql
@@ -1,0 +1,5 @@
+alter table if exists student_payment_history
+    add constraint FK_my_custom_fk_name
+    foreign key (payment_history_id)
+    references payment_history (payment_history_id)
+    on delete cascade


### PR DESCRIPTION
## Summary (작업사항)
현재 특정연월에 엑셀업로드를 할 경우 재업로드하는 것에 대한 처리가 안되어 있습니다. 따라서 프론트측에서 테스트 시 기존 엑셀업로드 내역을 삭제하는 것이 필요하여 PaymentHistory, PaymentKey, StudentPaymentHistory 객체 삭제 API를 통해 연관된 데이터를 삭제하도록 하였습니다.

## 변경사유

## Reference (Wiki)

## 체크리스트
1. paymentHistory 객체가 삭제될 경우 자식 객체인 studentPaymentHistory도 함께 제거여부
2. 기존 계획은 studentPaymentHistory가 삭제되면서 삭제된 student_id를 함께 가져와 student_id에 해당하는 payment_key를 제거하여 delete 쿼리만을 이용해 오버헤드를 최소화하는 방향이 어떨까 했으나 delete로는 어떤 컬럼이 삭제되었는지는 파악할 수 없는 것으로 파악되었습니다. 따라서 먼저 삭제할 student_id를 조회하여 찾아오는 방향으로 변경하여 select, delete 쿼리가 각각 나가도록 하였습니다. 해당부분 좀 더 좋은 방법이 있을지 체크부탁드립니다.

## 기타
