### PR TITLE
특정연월에 대한 납부데이터(엑셀데이터) 재 업로드에 대한 처리

### DIFF
--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
@@ -4,8 +4,10 @@ import com.edubill.edubillApi.domain.PaymentHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 
 public interface PaymentHistoryCustomRepository {
 

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
@@ -26,5 +26,5 @@ public interface PaymentHistoryCustomRepository {
 
     long deleteByUserIdAndYearMonth(String userId, YearMonth yearMonth);
 
-    Optional<PaymentHistory> findByDepositDateAndDepositorNameAndBankName(LocalDateTime depositDate, String depositorName, String bankName);
+    Optional<PaymentHistory> findByDepositDateAndDepositorNameAndBankNameAndManagerId(LocalDateTime depositDate, String depositorName, String bankName, String userId);
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
@@ -25,4 +25,6 @@ public interface PaymentHistoryCustomRepository {
     long countPaidUserGroupsForUserInMonth(String userId, YearMonth yearMonth);
 
     long deleteByUserIdAndYearMonth(String userId, YearMonth yearMonth);
+
+    Optional<PaymentHistory> findByDepositDateAndDepositorNameAndBankName(LocalDateTime depositDate, String depositorName, String bankName);
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryRepository.java
@@ -8,5 +8,4 @@ import java.time.LocalTime;
 import java.util.Optional;
 
 public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long>, PaymentHistoryCustomRepository {
-    Optional<PaymentHistory> findByDepositDateAndDepositorNameAndBankName(LocalDateTime depositDate, String depositorName, String bankName);
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryRepository.java
@@ -3,5 +3,10 @@ package com.edubill.edubillApi.repository.payment;
 import com.edubill.edubillApi.domain.PaymentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
 public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long>, PaymentHistoryCustomRepository {
+    Optional<PaymentHistory> findByDepositDateAndDepositorNameAndBankName(LocalDateTime depositDate, String depositorName, String bankName);
 }

--- a/src/main/java/com/edubill/edubillApi/service/PaymentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/PaymentService.java
@@ -12,7 +12,7 @@ import com.edubill.edubillApi.error.exception.PaymentKeyNotEncryptedException;
 import com.edubill.edubillApi.error.exception.UserNotFoundException;
 import com.edubill.edubillApi.repository.StudentPaymentHistoryRepository;
 import com.edubill.edubillApi.repository.payment.PaymentHistoryRepository;
-import com.edubill.edubillApi.repository.payment.PaymentKeyCustomRepository;
+
 import com.edubill.edubillApi.repository.payment.PaymentKeyRepository;
 import com.edubill.edubillApi.repository.student.StudentRepository;
 import com.edubill.edubillApi.repository.studentgroup.StudentGroupRepository;
@@ -52,11 +52,14 @@ public class PaymentService {
 
     @Transactional
     public void savePaymentHistories(List<PaymentHistory> paymentHistories) {
+        final String managerId = SecurityUtils.getCurrentUserId();
+
         for (PaymentHistory paymentHistory : paymentHistories) {
-            Optional<PaymentHistory> existingPaymentHistory = paymentHistoryRepository.findByDepositDateAndDepositorNameAndBankName(paymentHistory.getDepositDate(), paymentHistory.getDepositorName(), paymentHistory.getBankName());
+            Optional<PaymentHistory> existingPaymentHistory = paymentHistoryRepository.findByDepositDateAndDepositorNameAndBankNameAndManagerId(paymentHistory.getDepositDate(), paymentHistory.getDepositorName(), paymentHistory.getBankName(), managerId);
 
             if (existingPaymentHistory.isPresent()) {
                 PaymentHistory existing = existingPaymentHistory.get();
+                // 변경사항 추가
                 paymentHistoryRepository.save(existing);
             } else {
                 paymentHistoryRepository.save(paymentHistory);


### PR DESCRIPTION
## Summary (작업사항)
특정연월에 대해 엑셀데이터를 재 업로드하는 상황에 대해 중복데이터 생성하지 않고 기존 데이터 overwrite하도록 하였습니다.


## 변경사유
기존 데이터가 있는 상태에서 재 업로드하게 될 경우 새로 데이터가 생성되는 문제가 발생하여 같은 데이터의 경우 이러한 중복을 배제하기 위함

## Reference (Wiki)

## 체크리스트
1. 사용자가 최초 엑셀업로드 후 수동처리를 하지 않은 상태에서 재 업로드시 잘 동작하는가
2. 사용자가 최초 엑셀업로드 후 수동처리를 한 후 재 업로드 시에도 잘 동작하는가

## 기타
