### PR TITLE
fix: redis host update public ip

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -14,7 +14,7 @@ spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration
 
 #redis
-spring.data.redis.host=127.0.0.1
+spring.data.redis.host=15.164.219.148
 spring.data.redis.port=6379
 
 #jwt


### PR DESCRIPTION
## Summary (작업사항)
EB - 58 레디스 host  15.164.219.148 public ip로 변경했습니다.
## 변경사유
127.0.0.1 docker에서 접근하기 때문에 에러 발생 

## Reference (Wiki)

## 체크리스트

## 기타
