### PR TITLE
Add: 업로드된 엑셀 파일 삭제 시 excel_upload_status false로 변경

### DIFF
--- a/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/PaymentController.java
@@ -1,7 +1,9 @@
 package com.edubill.edubillApi.controller;
 
+import com.edubill.edubillApi.domain.User;
 import com.edubill.edubillApi.dto.FileUrlResponseDto;
 import com.edubill.edubillApi.dto.payment.*;
+import com.edubill.edubillApi.error.exception.UserNotFoundException;
 import com.edubill.edubillApi.service.excel.ExcelService;
 import com.edubill.edubillApi.service.PaymentService;
 import com.edubill.edubillApi.utils.SecurityUtils;
@@ -18,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -33,6 +36,7 @@ public class PaymentController {
 
     private final PaymentService paymentService;
     private final ExcelService excelService;
+
 
     public PaymentController(PaymentService paymentService, @Qualifier("excelServiceImpl") ExcelService excelService) {
         this.paymentService = paymentService;
@@ -188,5 +192,13 @@ public class PaymentController {
         String userId = SecurityUtils.getCurrentUserId();
 
         return ResponseEntity.ok(paymentService.getUnpaidStudentsList(userId, yearMonth));
+    }
+    @DeleteMapping("/deletePaymentHistory/{yearMonth}")
+    @Transactional
+    public ResponseEntity<String> deletePaymentData(@PathVariable(name = "yearMonth") YearMonth yearMonth) {
+        String userId = SecurityUtils.getCurrentUserId();
+        long deletedPaymentHistoryCount = paymentService.deleteExcelData(userId, yearMonth);
+
+        return ResponseEntity.ok("Deleted excel data: " + deletedPaymentHistoryCount );
     }
 }

--- a/src/main/java/com/edubill/edubillApi/repository/ExcelUploadStatusRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/ExcelUploadStatusRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface ExcelUploadStatusRepository extends JpaRepository<ExcelUploadStatus, Long> {
     Optional<ExcelUploadStatus> findByYearMonthAndUser(String yearMonth, User user);
 
+    void deleteAllByYearMonthAndUser(String yearMonth, User user);
 }

--- a/src/main/java/com/edubill/edubillApi/service/convert/KOOKMINConvertService.java
+++ b/src/main/java/com/edubill/edubillApi/service/convert/KOOKMINConvertService.java
@@ -72,7 +72,6 @@ public class KOOKMINConvertService implements ConvertService {
         }
         Sheet sheet = workbook.getSheetAt(0);
 
-        System.out.println(sheet.getLastRowNum()+ " "+ sheet.getPhysicalNumberOfRows());
         for (int rowNumber = 5; rowNumber < sheet.getPhysicalNumberOfRows() - 1; rowNumber++) {
 
             DataFormatter formatter = new DataFormatter();


### PR DESCRIPTION
## Summary (작업사항)
- 이미 업로드한 년월(yyyy-mm)에 대한 엑셀 파일에 대한 데이터를(payment_history, payment_key, student_payment_history) 삭제하면 excel_upload_status를 true 에서 false로 변경한다.
## 변경사유

## Reference (Wiki)

## 체크리스트
- 이 기능이 testController에 있던데, 다른 기능들 테스트 함에 있어서 프론트에서 삭제하기 편하게 일시적인 기능인지 아니면 후에 실제로 필요한 기능인지 궁금합니다. 만약 후자라면 리팩토링이 필요하다고 생각합니다.
## 기타
