### PR TITLE
[EB-85] 학생 상세 조회 및 통합 테스트 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ dependencies {
 	implementation group: 'io.awspring.cloud', name: 'spring-cloud-starter-aws-secrets-manager-config', version: '2.4.4'
 	implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0' // 3.13.0 버젼의 경우 호환성 문제로 오류 발생
 
+	// rest assured
+	testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }
 
 tasks.withType(Test).configureEach {

--- a/src/main/java/com/edubill/edubillApi/controller/StudentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/StudentController.java
@@ -65,6 +65,12 @@ public class StudentController {
         return ResponseEntity.ok(studentService.findAllStudentsByUserId(pageable));
     }
 
+    @Operation(summary = "학생 상세 조회",
+    description = "학생 ID 로 학생 상세 조회한다.")
+    @GetMapping("/{studentId}")
+    public ResponseEntity<StudentInfoDetailResponse> findStudentDetail(@PathVariable Long studentId) {
+        return ResponseEntity.ok(studentService.getStudentInfo(studentId));
+    }
 
     @Operation(summary = "학생 삭제",
             description = "특정 id에 해당하는 학생을 삭제한다.")

--- a/src/main/java/com/edubill/edubillApi/dto/student/GroupInfoDetailResponse.java
+++ b/src/main/java/com/edubill/edubillApi/dto/student/GroupInfoDetailResponse.java
@@ -1,7 +1,10 @@
 package com.edubill.edubillApi.dto.student;
 
 import com.edubill.edubillApi.domain.Group;
+import lombok.Getter;
 
+
+@Getter
 public class GroupInfoDetailResponse {
 
     private final String groupName;
@@ -12,8 +15,5 @@ public class GroupInfoDetailResponse {
 
     public static GroupInfoDetailResponse create(Group group) {
         return new GroupInfoDetailResponse(group.getGroupName());
-    }
-    public String getGroupName() {
-        return groupName;
     }
 }

--- a/src/main/java/com/edubill/edubillApi/dto/student/GroupInfoDetailResponse.java
+++ b/src/main/java/com/edubill/edubillApi/dto/student/GroupInfoDetailResponse.java
@@ -1,0 +1,19 @@
+package com.edubill.edubillApi.dto.student;
+
+import com.edubill.edubillApi.domain.Group;
+
+public class GroupInfoDetailResponse {
+
+    private final String groupName;
+
+    private GroupInfoDetailResponse(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public static GroupInfoDetailResponse create(Group group) {
+        return new GroupInfoDetailResponse(group.getGroupName());
+    }
+    public String getGroupName() {
+        return groupName;
+    }
+}

--- a/src/main/java/com/edubill/edubillApi/dto/student/StudentInfoDetailResponse.java
+++ b/src/main/java/com/edubill/edubillApi/dto/student/StudentInfoDetailResponse.java
@@ -2,9 +2,12 @@ package com.edubill.edubillApi.dto.student;
 
 
 import com.edubill.edubillApi.domain.Student;
+import lombok.Getter;
+
 import java.util.List;
 
 
+@Getter
 public class StudentInfoDetailResponse {
 
     private final String studentName;
@@ -56,44 +59,5 @@ public class StudentInfoDetailResponse {
     }
 
 
-    public String getStudentName() {
-        return studentName;
-    }
-
-    public String getStudentPhoneNumber() {
-        return studentPhoneNumber;
-    }
-
-    public String getParentName() {
-        return parentName;
-    }
-
-    public String getParentPhoneNumber() {
-        return parentPhoneNumber;
-    }
-
-    public List<GroupInfoDetailResponse> getGroups() {
-        return groups;
-    }
-
-    public String getSchoolLevel() {
-        return schoolLevel;
-    }
-
-    public String getGrade() {
-        return grade;
-    }
-
-    public String getDepartment() {
-        return department;
-    }
-
-    public String getSchoolName() {
-        return schoolName;
-    }
-
-    public String getMemo() {
-        return memo;
-    }
 }
 

--- a/src/main/java/com/edubill/edubillApi/dto/student/StudentInfoDetailResponse.java
+++ b/src/main/java/com/edubill/edubillApi/dto/student/StudentInfoDetailResponse.java
@@ -1,0 +1,99 @@
+package com.edubill.edubillApi.dto.student;
+
+
+import com.edubill.edubillApi.domain.Student;
+import java.util.List;
+
+
+public class StudentInfoDetailResponse {
+
+    private final String studentName;
+    private final String studentPhoneNumber;
+    private final String parentName;
+    private final String parentPhoneNumber;
+    private final List<GroupInfoDetailResponse> groups;
+    private final String schoolLevel;
+    private final String grade;
+    private final String department;
+    private final String schoolName;
+    private final String memo;
+
+    private StudentInfoDetailResponse(String studentName, String studentPhoneNumber, String parentName, String parentPhoneNumber, List<GroupInfoDetailResponse> groups,
+                                      String schoolLevel, String grade, String department, String schoolName, String memo) {
+        this.studentName = studentName;
+        this.studentPhoneNumber = studentPhoneNumber;
+        this.parentName = parentName;
+        this.parentPhoneNumber = parentPhoneNumber;
+        this.groups = groups;
+        this.schoolLevel = schoolLevel;
+        this.grade = grade;
+        this.department = department;
+        this.schoolName = schoolName;
+        this.memo = memo;
+    }
+
+    public static StudentInfoDetailResponse of(Student student) {
+
+        final List<GroupInfoDetailResponse> groups = student.getStudentGroups()
+                .stream()
+                .map(studentGroup -> GroupInfoDetailResponse.create(studentGroup.getGroup()))
+                .toList();
+
+        final String memo = student.getMemo() != null ? student.getMemo() : null;
+
+        return new StudentInfoDetailResponse(
+                student.getStudentName(),
+                student.getStudentPhoneNumber(),
+                student.getParentName(),
+                student.getParentPhoneNumber(),
+                groups,
+                student.getSchoolType().getDescription(),
+                student.getGradeLevel().getDescription(),
+                student.getDepartmentType().getDescription(),
+                student.getSchoolName(),
+                memo
+        );
+    }
+
+
+    public String getStudentName() {
+        return studentName;
+    }
+
+    public String getStudentPhoneNumber() {
+        return studentPhoneNumber;
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public String getParentPhoneNumber() {
+        return parentPhoneNumber;
+    }
+
+    public List<GroupInfoDetailResponse> getGroups() {
+        return groups;
+    }
+
+    public String getSchoolLevel() {
+        return schoolLevel;
+    }
+
+    public String getGrade() {
+        return grade;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public String getSchoolName() {
+        return schoolName;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+}
+

--- a/src/main/java/com/edubill/edubillApi/service/StudentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/StudentService.java
@@ -226,6 +226,14 @@ public class StudentService {
         groupRepository.save(group);
     }
 
+    public StudentInfoDetailResponse getStudentInfo(Long studentId) {
+        final Student findStudent = studentRepository.findById(studentId).orElseThrow(
+                () -> new StudentNotFoundException("Student not found with id " + studentId)
+        );
+
+        return StudentInfoDetailResponse.of(findStudent);
+    }
+
     private <T> List<Long> extractIds(List<T> entities, Function<T, Long> idExtractor) {
         return entities.stream()
                 .map(idExtractor)

--- a/src/test/java/com/edubill/edubillApi/integration/IntegrationTest.java
+++ b/src/test/java/com/edubill/edubillApi/integration/IntegrationTest.java
@@ -1,0 +1,25 @@
+package com.edubill.edubillApi.integration;
+
+import com.edubill.edubillApi.config.TestcontainerConfig;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestcontainerConfig
+public class IntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+
+    @BeforeEach
+    void setUp() {
+        // RestAssured 포트 설정
+        if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
+            RestAssured.port = port;
+        }
+    }
+}

--- a/src/test/java/com/edubill/edubillApi/integration/api/StudentApiTest.java
+++ b/src/test/java/com/edubill/edubillApi/integration/api/StudentApiTest.java
@@ -1,0 +1,80 @@
+package com.edubill.edubillApi.integration.api;
+
+import com.edubill.edubillApi.integration.IntegrationTest;
+import com.edubill.edubillApi.integration.steps.GroupSteps;
+import com.edubill.edubillApi.integration.steps.StudentSteps;
+import com.edubill.edubillApi.integration.steps.UserSteps;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StudentApiTest extends IntegrationTest {
+
+
+    @Test
+    @DisplayName("학생 조회 요청 API")
+    void 학생상세조회() {
+        // given
+        String phoneNumber = "01012345678";
+        String requestId = UserSteps.핸드폰인증후_회원가입_요청(phoneNumber);
+        var loginRequest = UserSteps.로그인모델_생성(requestId, phoneNumber);
+        var loginResponse = UserSteps.로그인_요청(loginRequest);
+        var groupRequest1 = GroupSteps.그룹모델_생성("기초 회화반");
+        var groupRequest2 = GroupSteps.그룹모델_생성("기초반");
+        var group1 = GroupSteps.그룹생성_요청(groupRequest1, loginResponse.header("Authorization"));
+        var group2 = GroupSteps.그룹생성_요청(groupRequest2, loginResponse.header("Authorization"));
+
+        List<Long> groupIds = List.of(group1.jsonPath().getLong("groupId"), group2.jsonPath().getLong("groupId"));
+
+        // when
+        var studentRequest = StudentSteps.학생모델_생성("s1",groupIds);
+        var studentResponse = StudentSteps.학생생성_요청(studentRequest, loginResponse.header("Authorization"));
+
+        var response = StudentSteps.학생_상세조회_요청(studentResponse.jsonPath().getLong("studentId"), loginResponse.header("Authorization"));
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+    @Test
+    @DisplayName("그룹 생성 API")
+    void 그룹생성() {
+        // given
+        String phoneNumber = "01012345678";
+        String requestId = UserSteps.핸드폰인증후_회원가입_요청(phoneNumber);
+        var loginRequest = UserSteps.로그인모델_생성(requestId, phoneNumber);
+        var loginResponse = UserSteps.로그인_요청(loginRequest);
+
+        // when
+        var groupRequest = GroupSteps.그룹모델_생성("기초 회화반");
+        var response = GroupSteps.그룹생성_요청(groupRequest, loginResponse.header("Authorization"));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("학생 생성 요청 API")
+    void 학생생성() {
+        // given
+        String phoneNumber = "01012345678";
+        String requestId = UserSteps.핸드폰인증후_회원가입_요청(phoneNumber);
+        var loginRequest = UserSteps.로그인모델_생성(requestId, phoneNumber);
+        var loginResponse = UserSteps.로그인_요청(loginRequest);
+        var groupRequest1 = GroupSteps.그룹모델_생성("기초 회화반");
+        var groupRequest2 = GroupSteps.그룹모델_생성("기초반");
+        var group1 = GroupSteps.그룹생성_요청(groupRequest1, loginResponse.header("Authorization"));
+        var group2 = GroupSteps.그룹생성_요청(groupRequest2, loginResponse.header("Authorization"));
+
+        List<Long> groupIds = List.of(group1.jsonPath().getLong("groupId"), group2.jsonPath().getLong("groupId"));
+
+        // when
+        var studentRequest = StudentSteps.학생모델_생성("s1",groupIds);
+        var response = StudentSteps.학생생성_요청(studentRequest, loginResponse.header("Authorization"));
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+}

--- a/src/test/java/com/edubill/edubillApi/integration/api/UserApiTest.java
+++ b/src/test/java/com/edubill/edubillApi/integration/api/UserApiTest.java
@@ -1,0 +1,65 @@
+package com.edubill.edubillApi.integration.api;
+
+import com.edubill.edubillApi.integration.IntegrationTest;
+import com.edubill.edubillApi.integration.steps.UserSteps;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class UserApiTest extends IntegrationTest {
+
+
+    @Test
+    @DisplayName("로그인 API")
+    void loginApiTest() {
+        // given
+        String phoneNumber = "01012345678";
+        String requestId = UserSteps.핸드폰인증후_회원가입_요청(phoneNumber);
+
+        // when
+        var loginRequest = UserSteps.로그인모델_생성(requestId, phoneNumber);
+        var response = UserSteps.로그인_요청(loginRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("회원가입 API")
+    void signUpApiTest() {
+        // given
+        String phoneNumber = "01012345678";
+        String requestId = UserSteps.핸드폰인증_요청(phoneNumber);
+
+        // when then
+        var signUpRequest = UserSteps.회원가입모델_생성(requestId, phoneNumber);
+        var response = UserSteps.회원가입_요청(signUpRequest);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("핸드폰 인증 번호 요청 API")
+    void requestVerificationNumberApiTest() {
+        // given
+        String phoneNumber = "01012345678";
+        var verificationRequest = UserSteps.핸드폰_인증번호_모델_생성(phoneNumber);
+
+        // when
+        var response = UserSteps.핸드폰_인증번호_요청(verificationRequest);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("핸드폰 인증 번호 확인 API")
+    void verifyVerificationNumberApiTest() {
+        String phoneNumber = "01012345678";
+        String requestId = UserSteps.핸드폰인증_요청(phoneNumber);
+
+        assertThat(requestId).isNotNull();
+    }
+}

--- a/src/test/java/com/edubill/edubillApi/integration/steps/GroupSteps.java
+++ b/src/test/java/com/edubill/edubillApi/integration/steps/GroupSteps.java
@@ -1,0 +1,55 @@
+package com.edubill.edubillApi.integration.steps;
+
+import com.edubill.edubillApi.domain.enums.DayOfWeek;
+import com.edubill.edubillApi.domain.enums.GradeLevel;
+import com.edubill.edubillApi.domain.enums.SchoolType;
+import com.edubill.edubillApi.dto.group.GroupInfoRequestDto;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.time.LocalTime;
+import java.time.temporal.TemporalAmount;
+import java.util.List;
+
+public class GroupSteps {
+
+    public static GroupInfoRequestDto 그룹모델_생성(String groupName) {
+
+        GroupInfoRequestDto.ClassTimeRequestDto classTimeRequestDto1 = createClassTimeRequestDto(DayOfWeek.MON, "14:00", "18:00");
+        GroupInfoRequestDto.ClassTimeRequestDto classTimeRequestDto2 = createClassTimeRequestDto(DayOfWeek.FRI, "14:00", "18:00");
+
+        List<GroupInfoRequestDto.ClassTimeRequestDto> classTimeRequestDtos = List.of(classTimeRequestDto1, classTimeRequestDto2);
+
+        return GroupInfoRequestDto.builder()
+                .groupName(groupName)
+                .groupMemo("반 메모")
+                .tuition(100000)
+                .schoolType(SchoolType.HIGH)
+                .gradeLevel(GradeLevel.THIRD)
+                .classTimeRequestDtos(classTimeRequestDtos)
+                .build();
+    }
+
+    public static ExtractableResponse<Response> 그룹생성_요청(GroupInfoRequestDto groupInfoRequestDto, String authorizationToken) {
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .header("Authorization", authorizationToken)
+                .body(groupInfoRequestDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/v1/student/groups")
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+
+    private static  GroupInfoRequestDto.ClassTimeRequestDto createClassTimeRequestDto(DayOfWeek dayOfWeek, String startTime, String endTime) {
+        return GroupInfoRequestDto.ClassTimeRequestDto.builder()
+                .dayOfWeek(dayOfWeek)
+                .startTime(LocalTime.parse(startTime))
+                .endTime(LocalTime.parse(endTime))
+                .build();
+    }
+}

--- a/src/test/java/com/edubill/edubillApi/integration/steps/StudentSteps.java
+++ b/src/test/java/com/edubill/edubillApi/integration/steps/StudentSteps.java
@@ -1,0 +1,54 @@
+package com.edubill.edubillApi.integration.steps;
+
+import com.edubill.edubillApi.domain.enums.DepartmentType;
+import com.edubill.edubillApi.domain.enums.GradeLevel;
+import com.edubill.edubillApi.domain.enums.SchoolType;
+import com.edubill.edubillApi.dto.student.StudentInfoRequestDto;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+public class StudentSteps {
+
+    public static StudentInfoRequestDto 학생모델_생성(String studentName, List<Long> groupIds) {
+        return StudentInfoRequestDto.builder()
+                .studentName(studentName)
+                .studentPhoneNumber("01012341234")
+                .departmentType(DepartmentType.LIBERAL_ARTS)
+                .schoolName("서울고등학교")
+                .memo("진도 매우 느림")
+                .gradeLevel(GradeLevel.SIXTH)
+                .schoolType(SchoolType.HIGH)
+                .parentPhoneNumber("01098769876")
+                .parentName("p1")
+                .groupIds(groupIds)
+                .build();
+    }
+
+    public static ExtractableResponse<Response> 학생생성_요청(final StudentInfoRequestDto request, final String authorizationToken) {
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .header("Authorization", authorizationToken)
+                .body(request)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/v1/student")
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+
+    public static ExtractableResponse<Response> 학생_상세조회_요청(final Long studentId, final String authorizationToken) {
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .header("Authorization", authorizationToken)
+                .when()
+                .get("/v1/student/{studentId}", studentId)
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+}

--- a/src/test/java/com/edubill/edubillApi/integration/steps/UserSteps.java
+++ b/src/test/java/com/edubill/edubillApi/integration/steps/UserSteps.java
@@ -1,0 +1,103 @@
+package com.edubill.edubillApi.integration.steps;
+
+import com.edubill.edubillApi.dto.auth.VerificationNumberRequestDto;
+import com.edubill.edubillApi.dto.auth.VerificationRequestDto;
+import com.edubill.edubillApi.dto.user.LoginRequestDto;
+import com.edubill.edubillApi.dto.user.SignupRequestDto;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserSteps {
+
+    public static LoginRequestDto 로그인모델_생성(String requestId, String phoneNumber) {
+        return new LoginRequestDto(requestId, phoneNumber);
+    }
+
+    public static ExtractableResponse<Response> 로그인_요청(LoginRequestDto loginRequestDto) {
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(loginRequestDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/v1/auth/login")
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+
+    public static VerificationNumberRequestDto 핸드폰_인증번호_모델_생성(String phoneNumber) {
+        return new VerificationNumberRequestDto(phoneNumber);
+    }
+
+    public static ExtractableResponse<Response> 핸드폰_인증번호_요청(VerificationNumberRequestDto verificationNumberRequestDto) {
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(verificationNumberRequestDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/v1/auth/phone")
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+
+    public static VerificationRequestDto 핸드폰인증확인_모델_생성(String requestId, String verificationNumber,String phoneNumber) {
+        return new VerificationRequestDto(requestId, verificationNumber ,phoneNumber);
+    }
+
+    public static ExtractableResponse<Response> 핸드폰인증확인_요청(VerificationRequestDto verificationRequestDto) {
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(verificationRequestDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/v1/auth/verify")
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+
+
+    public static SignupRequestDto 회원가입모델_생성(final String requestId, final String phoneNumber) {
+        return new SignupRequestDto(requestId, "userA", phoneNumber);
+    }
+
+    public static ExtractableResponse<Response> 회원가입_요청(SignupRequestDto signupRequestDto) {
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(signupRequestDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/v1/auth/signup")
+                .then().log().all()
+                .extract();
+
+        return response;
+    }
+
+    public static String 핸드폰인증후_회원가입_요청(String phoneNumber) {
+        String requestId = 핸드폰인증_요청(phoneNumber);
+
+        var signUpRequest = UserSteps.회원가입모델_생성(requestId, phoneNumber);
+        var signUpResponse = UserSteps.회원가입_요청(signUpRequest);
+
+        assertThat(signUpResponse.statusCode()).isEqualTo(200);
+
+        return requestId;
+    }
+
+    public static String 핸드폰인증_요청(String phoneNumber) {
+        var verificationRequest = UserSteps.핸드폰_인증번호_모델_생성(phoneNumber);
+        var verificationResponse = UserSteps.핸드폰_인증번호_요청(verificationRequest);
+        var verificationCode = verificationResponse.body().jsonPath().getString("verificationNumber");
+        var requestId = verificationResponse.body().jsonPath().getString("requestId");
+
+        var verificationModel = UserSteps.핸드폰인증확인_모델_생성(requestId, verificationCode, phoneNumber);
+        var verifyModel = UserSteps.핸드폰인증확인_요청(verificationModel);
+
+        return requestId; // requestId 반환
+    }
+}

--- a/src/test/java/com/edubill/edubillApi/service/StudentTest.java
+++ b/src/test/java/com/edubill/edubillApi/service/StudentTest.java
@@ -1,0 +1,153 @@
+package com.edubill.edubillApi.service;
+
+
+import com.edubill.edubillApi.config.TestcontainerConfig;
+import com.edubill.edubillApi.domain.Group;
+import com.edubill.edubillApi.domain.Student;
+import com.edubill.edubillApi.domain.StudentGroup;
+import com.edubill.edubillApi.domain.enums.DepartmentType;
+import com.edubill.edubillApi.domain.enums.GradeLevel;
+import com.edubill.edubillApi.domain.enums.SchoolType;
+import com.edubill.edubillApi.dto.student.StudentInfoDetailResponse;
+import com.edubill.edubillApi.dto.student.StudentInfoResponseDto;
+import com.edubill.edubillApi.error.exception.StudentNotFoundException;
+import com.edubill.edubillApi.repository.StudentGroupRepository;
+import com.edubill.edubillApi.repository.group.GroupRepository;
+import com.edubill.edubillApi.repository.student.StudentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@TestcontainerConfig
+@Transactional
+public class StudentTest {
+
+     @Autowired
+     StudentService studentService;
+     @Autowired
+     StudentRepository studentRepository;
+     @Autowired
+     GroupRepository groupRepository;
+     @Autowired
+     StudentGroupRepository studentGroupRepository;
+
+    private Student student;
+    private Group savedGroup1;
+    private Group savedGroup2;
+
+    @BeforeEach
+    void setUp() {
+        student = createStudent(
+                "s1",
+                "01012341234",
+                "p1",
+                "01098769876",
+                "서울고등학교",
+                "학업 진도 느림"
+        );
+        studentRepository.save(student);
+
+        savedGroup1 = groupRepository.save(createGroup("기초 회화반", "testManager"));
+        savedGroup2 = groupRepository.save(createGroup("기초반", "testManager"));
+
+        createAndSaveStudentGroup(student, savedGroup1);
+        createAndSaveStudentGroup(student, savedGroup2);
+    }
+
+    @Test
+    @DisplayName("학생 ID로 학생 상세 정보를 조회한다.")
+    void shouldReturnStudentDetailsWhenGivenStudentId() {
+        // When: 학생의 상세 정보 조회
+        final StudentInfoDetailResponse result = studentService.getStudentInfo(student.getId());
+
+        // Then: 조회된 정보 검증
+        assertStudentDetails(result);
+        assertGroupDetails(result);
+    }
+
+    @Test
+    @DisplayName("잘못된 학생 ID로 조회했을 경우 StudentNotFoundException을 발생한다.")
+    void shouldThrowStudentNotFoundExceptionWhenInvalidStudentIdIsProvided() {
+        // Given: 잘못된 아이디
+        final Long invalidStudentId = -1L;
+
+        // When, Then: Exception 검증
+        assertThatThrownBy(() -> studentService.getStudentInfo(invalidStudentId))
+                .isInstanceOf(StudentNotFoundException.class)
+                .hasMessageContaining("Student not found with id " + invalidStudentId);
+    }
+
+    // 학생 정보 검증
+    private void assertStudentDetails(StudentInfoDetailResponse result) {
+        assertThat(result.getStudentName()).isEqualTo("s1");
+        assertThat(result.getStudentPhoneNumber()).isEqualTo("01012341234");
+        assertThat(result.getParentName()).isEqualTo("p1");
+        assertThat(result.getParentPhoneNumber()).isEqualTo("01098769876");
+        assertThat(result.getSchoolName()).isEqualTo("서울고등학교");
+        assertThat(result.getMemo()).isEqualTo("학업 진도 느림");
+        assertThat(result.getSchoolLevel()).isEqualTo(SchoolType.HIGH.getDescription());
+        assertThat(result.getDepartment()).isEqualTo(DepartmentType.LIBERAL_ARTS.getDescription());
+        assertThat(result.getGrade()).isEqualTo(GradeLevel.SIXTH.getDescription());
+    }
+
+    // 그룹 정보 검증 메서드
+    private void assertGroupDetails(StudentInfoDetailResponse result) {
+        assertThat(result.getGroups())
+                .hasSize(2)
+                .extracting("groupName")
+                .containsExactlyInAnyOrder("기초 회화반", "기초반");
+    }
+
+    // 학생 생성 메서드
+    private Student createStudent(String studentName,
+                                  String phoneNumber,
+                                  String parentName,
+                                  String parentPhoneNumber,
+                                  String schoolName,
+                                  String memo) {
+        return Student.builder()
+                .studentName(studentName)
+                .studentPhoneNumber(phoneNumber)
+                .parentName(parentName)
+                .parentPhoneNumber(parentPhoneNumber)
+                .schoolType(SchoolType.HIGH)
+                .gradeLevel(GradeLevel.SIXTH)
+                .departmentType(DepartmentType.LIBERAL_ARTS)
+                .schoolName(schoolName)
+                .memo(memo)
+                .build();
+    }
+
+    // 그룹 생성 메서드
+    private Group createGroup(String groupName, String managerId) {
+        return Group.builder()
+                .groupName(groupName)
+                .managerId(managerId)
+                .build();
+    }
+
+    // 학생 그룹 생성 및 저장 메서드
+    private void createAndSaveStudentGroup(Student student, Group group) {
+        StudentGroup studentGroup = createStudentGroup(student, group);
+        studentGroupRepository.save(studentGroup);
+    }
+
+    // 학생-그룹 연결 생성 메서드
+    private StudentGroup createStudentGroup(Student student, Group group) {
+        StudentGroup studentGroup = StudentGroup.builder()
+                .student(student)
+                .group(group)
+                .build();
+
+        studentGroup.setGroup(group);
+        studentGroup.setStudent(student);
+        return studentGroup;
+    }
+}


### PR DESCRIPTION
## Summary (작업사항)
- 학생 상세 조회 API 
- Get 
- ```/v1/student/{studentId}```

- response
```json
{
    "studentName": "s1",
    "studentPhoneNumber": "01012341234",
    "parentName": "p1",
    "parentPhoneNumber": "01098769876",
    "groups": [
        {
            "groupName": "기초 회화반"
        },
        {
            "groupName": "기초반"
        }
    ],
    "schoolLevel": "고등학교",
    "grade": "6학년",
    "department": "문과",
    "schoolName": "서울고등학교",
    "memo": "진도 매우 느림"
}
```
## 변경사유

## Reference (Wiki)

## 체크리스트: 통합 테스트 작업
- 작업 내용
API 테스트 코드 작성: 현재 인증(Auth) 로직만 테스트 코드가 작성되어 있는 상태이므로, 로그인, 학생, 그룹 생성에 대한 통합테스트 작성했음
- 따라서 만약 api 만들때마다 계속 통합테스트 작성하여 시스템의 안정성 보장하는게 좋을듯 합니다.
RestAssured 사용: RestAssured 라이브러리를 활용하여 실제 API 호출 기반의 통합 테스트 구현
## 기타
