### PR TITLE
[feature/EB-88] 반 상세정보 수정

### DIFF
--- a/src/main/java/com/edubill/edubillApi/controller/StudentController.java
+++ b/src/main/java/com/edubill/edubillApi/controller/StudentController.java
@@ -27,12 +27,6 @@ public class StudentController {
 
     private final StudentService studentService;
 
-    @Operation(summary = "새로운 원생 추가",
-            description = "새로운 학생정보를 추가한다.")
-    @PostMapping
-    public ResponseEntity<StudentInfoResponseDto> addStudentInfo(@RequestBody StudentInfoRequestDto studentInfoRequestDto) {
-        return ResponseEntity.ok(studentService.addStudentInfo(studentInfoRequestDto));
-    }
 
     @Operation(summary = "새로운 반 추가",
             description = "새로운 반 정보를 추가한다.")
@@ -56,6 +50,27 @@ public class StudentController {
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(studentService.findAllGroupsByUserId(pageable));
+    }
+
+    @Operation(summary = "반 삭제",
+            description = "특정 id에 해당하는 반을 삭제한다.")
+    @DeleteMapping("/groups/{groupId}")
+    public ResponseEntity<DeletedGroupInfoDto> deleteGroupInfo(@PathVariable(name = "groupId") Long groupId) {
+        return ResponseEntity.ok(studentService.deleteGroupInfo(groupId));
+    }
+
+    @Operation(summary = "반 정보 수정",
+            description = "반 정보를 수정한다.")
+    @PutMapping("/groups/{groupId}")
+    public ResponseEntity<GroupInfoResponseDto> updateStudentGroupInfo(@PathVariable(name = "groupId") Long groupId, @RequestBody GroupInfoRequestDto groupInfoRequestDto) {
+        return ResponseEntity.ok(studentService.updateGroupInfo(groupId, groupInfoRequestDto));
+    }
+
+    @Operation(summary = "새로운 원생 추가",
+            description = "새로운 학생정보를 추가한다.")
+    @PostMapping
+    public ResponseEntity<StudentInfoResponseDto> addStudentInfo(@RequestBody StudentInfoRequestDto studentInfoRequestDto) {
+        return ResponseEntity.ok(studentService.addStudentInfo(studentInfoRequestDto));
     }
 
     @GetMapping("/allStudents")
@@ -159,10 +174,5 @@ public class StudentController {
         return ResponseEntity.ok(studentService.deleteStudentInfo(studentId));
     }
 
-    @Operation(summary = "반 삭제",
-            description = "특정 id에 해당하는 반을 삭제한다.")
-    @DeleteMapping("/groups/{groupId}")
-    public ResponseEntity<DeletedGroupInfoDto> deleteGroupInfo(@PathVariable(name = "groupId") Long groupId) {
-        return ResponseEntity.ok(studentService.deleteGroupInfo(groupId));
-    }
+
 }

--- a/src/main/java/com/edubill/edubillApi/domain/Group.java
+++ b/src/main/java/com/edubill/edubillApi/domain/Group.java
@@ -71,6 +71,16 @@ public class Group extends BaseEntity {
         return new Group(groupInfoRequestDto, userId);
     }
 
+    public Group updateGroup(GroupInfoRequestDto groupInfoRequestDto){
+        this.groupName = groupInfoRequestDto.getGroupName();
+        this.schoolType = groupInfoRequestDto.getSchoolType();
+        this.gradeLevel = groupInfoRequestDto.getGradeLevel();
+        this.tuition = groupInfoRequestDto.getTuition();
+        this.groupMemo = groupInfoRequestDto.getGroupMemo();
+
+        return this;
+    }
+
     //학생수 추가 로직
     public void addStudentCount() {
         if (this.totalStudentCount != null) {

--- a/src/main/java/com/edubill/edubillApi/dto/student/StudentsListRequestDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/student/StudentsListRequestDto.java
@@ -1,0 +1,30 @@
+package com.edubill.edubillApi.dto.student;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StudentsListRequestDto {
+    @Schema(description = "groupIds", type = "List<Long>", example = "{1, 2, 3}")
+    private List<Long> groupIds;
+
+    @Schema(description = "isUnpaid", type = "string", example = "true", defaultValue = "false")
+    @NotNull(message = "미납입 조회 여부는 필수입니다.")
+    private Boolean isUnpaid;
+
+    @Schema(description = "studentName", type = "String", example = "학생1")
+    private String studentName;
+
+    @Schema(description = "studentPhoneNumber", type = "String", example = "01012345678")
+    private String studentPhoneNumber;
+
+    @Schema(description = "정렬기준 / studentName(가나다순) || id(최신등록순)", type = "String", example = "id", defaultValue = "id")
+    @NotNull(message = "정렬 기준은 필수입니다.")
+    private String sort;
+}

--- a/src/main/java/com/edubill/edubillApi/repository/ClassTimeRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/ClassTimeRepository.java
@@ -1,10 +1,17 @@
 package com.edubill.edubillApi.repository;
 
 import com.edubill.edubillApi.domain.ClassTime;
+import com.edubill.edubillApi.domain.Group;
+import com.edubill.edubillApi.domain.enums.DayOfWeek;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalTime;
 import java.util.List;
 
 public interface ClassTimeRepository extends JpaRepository<ClassTime, Long> {
     List<ClassTime> findByGroupId(long groupId);
+    void deleteByClassTimeId(Long classTimeId);
 }

--- a/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepository.java
@@ -18,7 +18,7 @@ public interface StudentCustomRepository {
     List<Student> findAllByUserId(String currentUserId);
 
     Page<Student> getStudentsByUserIdWithPaging(String currentUserId, Pageable pageable);
-    Page<Student> getStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable,Long groupId, String nameOrPhoneNum);
-    Page<Student> getUnpaidStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable,Long groupId, String nameOrPhoneNum);
+    Page<Student> getStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable, List<Long> groupIds, String studentName, String studentPhoneNumber);
+    Page<Student> getUnpaidStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable, List<Long> groupId, String studentName, String studentPhoneNumber);
 
 }

--- a/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepositoryImpl.java
@@ -245,7 +245,7 @@ public class StudentCustomRepositoryImpl implements StudentCustomRepository {
             builder.and(group.id.in(groupIds));
         }
         if (!Objects.isNull(studentName)){
-            builder.and(student.studentName.eq(studentName));
+            builder.and(student.studentName.contains(studentName));
         }
         if (!Objects.isNull(studentPhoneNumber)){
             builder.and(student.studentPhoneNumber.eq(studentPhoneNumber));

--- a/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/student/StudentCustomRepositoryImpl.java
@@ -23,6 +23,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.edubill.edubillApi.domain.QGroup.group;
@@ -193,7 +194,7 @@ public class StudentCustomRepositoryImpl implements StudentCustomRepository {
     }
 
     @Override
-    public Page<Student> getStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable, Long groupId, String nameOrPhoneNum) {
+    public Page<Student> getStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable, List<Long> groupIds, String studentName, String studentPhoneNumber) {
         QGroup group = QGroup.group;
         QStudentGroup studentGroup = QStudentGroup.studentGroup;
         QStudent student = QStudent.student;
@@ -201,17 +202,14 @@ public class StudentCustomRepositoryImpl implements StudentCustomRepository {
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (groupId != null) {
-            builder.and(group.id.eq(groupId));
+        if (!Objects.isNull(groupIds)) {
+            builder.and(group.id.in(groupIds));
         }
-        if (nameOrPhoneNum != null) {
-            boolean isPhoneNum = nameOrPhoneNum.matches("^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$"); // 필터링 조건이 전화번호인지 이름인지 판별
-            if (isPhoneNum == true) {// 판별 조건이 핸드폰번호 일 경우{
-                builder.and(student.studentPhoneNumber.eq(nameOrPhoneNum));
-            }
-            else {
-                builder.and(student.studentName.eq(nameOrPhoneNum));
-            }
+        if (!Objects.isNull(studentName)){
+            builder.and(student.studentName.eq(studentName));
+        }
+        if (!Objects.isNull(studentPhoneNumber)){
+            builder.and(student.studentPhoneNumber.eq(studentPhoneNumber));
         }
 
         // 기본 쿼리 설정
@@ -236,24 +234,21 @@ public class StudentCustomRepositoryImpl implements StudentCustomRepository {
     }
 
     @Override
-    public Page<Student> getUnpaidStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable, Long groupId, String nameOrPhoneNum) {
+    public Page<Student> getUnpaidStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(String currentUserId, Pageable pageable, List<Long> groupIds, String studentName, String studentPhoneNumber) {
         QGroup group = QGroup.group;
         QStudentGroup studentGroup = QStudentGroup.studentGroup;
         QStudent student = QStudent.student;
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (groupId != null) {
-            builder.and(group.id.eq(groupId));
+        if (!Objects.isNull(groupIds)) {
+            builder.and(group.id.in(groupIds));
         }
-        if (nameOrPhoneNum != null) {
-            boolean isPhoneNum = nameOrPhoneNum.matches("^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$"); // 필터링 조건이 전화번호인지 이름인지 판별
-            if (isPhoneNum == true) {// 판별 조건이 핸드폰번호일 경우{
-                builder.and(student.studentPhoneNumber.eq(nameOrPhoneNum));
-            }
-            else { // 판별 조건이 학생이름일 경루
-                builder.and(student.studentName.eq(nameOrPhoneNum));
-            }
+        if (!Objects.isNull(studentName)){
+            builder.and(student.studentName.eq(studentName));
+        }
+        if (!Objects.isNull(studentPhoneNumber)){
+            builder.and(student.studentPhoneNumber.eq(studentPhoneNumber));
         }
 
         String sYearMonth = YearMonth.now().toString();

--- a/src/main/java/com/edubill/edubillApi/service/StudentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/StudentService.java
@@ -127,15 +127,15 @@ public class StudentService {
 
     }
 
-    public Page<StudentAndGroupResponseDto> findStudentsByUserIdAndGroupIdOrNameOrPhoneNum(Pageable pageable, String isUnpaid, Long groupId, String nameOrPhoneNum) {
+    public Page<StudentAndGroupResponseDto> findStudentsByUserIdAndGroupIdOrNameOrPhoneNum(Pageable pageable, Boolean isUnpaid, List<Long> groupIds, String studentName, String studentPhoneNumber) {
 
         String currentId = SecurityUtils.getCurrentUserId();
-        if (isUnpaid.equals("false")){ // 납입 여부 구분 안함
-            Page<Student> students = studentRepository.getStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(currentId, pageable, groupId, nameOrPhoneNum);
+        if (isUnpaid.equals(false)){ // 납입 여부 구분 안함
+            Page<Student> students = studentRepository.getStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(currentId, pageable, groupIds, studentName, studentPhoneNumber);
             return studentMapToStudentAndGroupResponseDtowWithPaging(students);
         }
         else { // 미납입자 조회
-            Page<Student> students = studentRepository.getUnpaidStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(currentId, pageable, groupId, nameOrPhoneNum);
+            Page<Student> students = studentRepository.getUnpaidStudentsByUserIdAndGroupIdOrStudentNameOrPhoneNumWithPaging(currentId, pageable, groupIds, studentName, studentPhoneNumber);
             return studentMapToStudentAndGroupResponseDtowWithPaging(students);
 
         }

--- a/src/main/java/com/edubill/edubillApi/service/StudentService.java
+++ b/src/main/java/com/edubill/edubillApi/service/StudentService.java
@@ -304,7 +304,6 @@ public class StudentService {
         })).collect(Collectors.toList());
 
         deletedClassTime.stream().forEach(classTime -> {
-            System.out.println(classTime.getDayOfWeek());
             updatedGroup.getClassTimes().remove(classTime);
             classTimeRepository.deleteByClassTimeId(classTime.getClassTimeId());
         });
@@ -314,10 +313,7 @@ public class StudentService {
             return o.getDayOfWeek().equals(n.getDayOfWeek()) && o.getStartTime().equals(n.getStartTime()) && o.getEndTime().equals(n.getEndTime());
         })).collect(Collectors.toList());
 
-        createdClassTime.stream().forEach(classTime -> {
-            System.out.println(classTime.getDayOfWeek());
-            classTime.setGroup(updatedGroup);
-        });
+        createdClassTime.stream().forEach(classTime -> classTime.setGroup(updatedGroup));
         classTimeRepository.saveAll(createdClassTime);
 
 


### PR DESCRIPTION
## Summary (작업사항)
- 기존 반의 상세정보를 변경하는 API 입니다.

> - 반 이름, schoolType(초,중,고), groupLevel(학년), 수업료, 반 메모, 수업시간

> - 수업시간 변경 같은 경우, 원래 수업시간 list와 업데이트할 수업시간 list를 비교하여 

> - 기존에는 있지만 업데이트에는 없는 수업시간은 삭제하고 업데이트에는 있지만 기존에는 없는 수업시간은 객체 생성 및 저장하여 group과 연관시키는 로직으로 구현했습니다.

- 학생 조회 기능에서 단일 반 아이디로 조회하는 것이 아닌 다중 반 아이디로도 조회 가능하게 수정하였습니다.
- 학생 조회 기능에서 학생이름에 일부 문자열 포함된 경우 모두 조회될 수 있게 수정하였습니다.

## 변경사유

## Reference (Wiki)

## 체크리스트
- 수업시간 업데이트와 관련해서 더 좋은 방법 있으시면 조언 부탁드립니다.
## 기타
