### PR TITLE
[Fix/eb 3] 해당연월 납부현황 조회 기능 - 미확인 입금내역 속성 및 로직 추가

### DIFF
--- a/src/main/java/com/edubill/edubillApi/dto/payment/PaymentStatusDto.java
+++ b/src/main/java/com/edubill/edubillApi/dto/payment/PaymentStatusDto.java
@@ -11,9 +11,11 @@ public class PaymentStatusDto{
 
         private Long unpaidCount;  // 미 납부 인원
 
-        private Long totalPaidAmount;
+        private Long totalPaidAmount; // 납부 완료 금액
 
-        private Long totalUnpaidAmount;
+        private Long totalUnpaidAmount; // 미납부 금액
+
+        private Long totalUnCheckedAmount; // 미확인 납부 금액 : 학생 목록에는 없으나 입금내역에는 존재
 
         private Boolean isExcelUploaded; //default는 false
 }

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepository.java
@@ -17,7 +17,9 @@ public interface PaymentHistoryCustomRepository {
 
     List<PaymentHistory> findPaymentHistoriesByUserIdAndYearMonthWithPaymentStatusPaid(String managerId, YearMonth yearMonth);
 
-    List<PaymentHistory> findPaymentHistoriesByUserIdAndYearMonth(String managerId, YearMonth yearMonth);
+    List<PaymentHistory> findPaymentHistoriesByManagerIdAndYearMonthWithPaymentStatusUnPaid(String managerId, YearMonth yearMonth);
+
+    List<PaymentHistory> findPaymentHistoriesByManagerIdAndYearMonth(String managerId, YearMonth yearMonth);
 
     long countPaidStudentsForUserInMonth(String userId, YearMonth yearMonth);
 

--- a/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/edubill/edubillApi/repository/payment/PaymentHistoryCustomRepositoryImpl.java
@@ -118,7 +118,24 @@ public class PaymentHistoryCustomRepositoryImpl implements PaymentHistoryCustomR
     }
 
     @Override
-    public List<PaymentHistory> findPaymentHistoriesByUserIdAndYearMonth(String userId, YearMonth yearMonth){
+    public List<PaymentHistory> findPaymentHistoriesByManagerIdAndYearMonthWithPaymentStatusUnPaid(String managerId, YearMonth yearMonth) {
+        // 월의 첫째 날
+        LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay(); // 해당 월의 첫 날 자정
+        // 월의 마지막 날
+        LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999); // 해당 월의 마지막 날 23시 59분 59초 999999999나노초
+
+        return queryFactory
+                .selectFrom(paymentHistory)
+                .join(user)
+                .on(paymentHistory.managerId.eq(user.userId))
+                .where(paymentHistory.depositDate.between(startDateTime, endDateTime)
+                        .and(user.userId.eq(managerId))
+                        .and(paymentHistory.paymentStatus.eq(PaymentStatus.UNPAID)))
+                .fetch();
+    }
+
+    @Override
+    public List<PaymentHistory> findPaymentHistoriesByManagerIdAndYearMonth(String userId, YearMonth yearMonth){
 
         LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime endDateTime = yearMonth.atEndOfMonth().atTime(23, 59, 59, 999999999);


### PR DESCRIPTION
## Summary (작업사항)
- 이전에는 해당연월 납부현황 기능에서는 다음과 같은 속성을 조회할 수 있었습니다.

> - 납부 확인된 학생 수
> - 미납부한 학생 수
> - 납부된 총 금액
> - 미납부 총 금액

- 여기에 " 미납입 입금내역 총 금액" 속성을 추가하였습니다. 미납입 입금내역이란 입금자명이 학생 리스트에서는 조회되지 않으나 입금내역 리스트에는 존재하는 경우를 의미합니다

## 변경사유

## Reference (Wiki)

## 체크리스트

## 기타
